### PR TITLE
Compose fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,9 @@ version publish_version
 
 buildscript {
     repositories {
+        // TODO WORKAROUND: https://github.com/JetBrains/markdown/issues/70
+        maven { url 'https://dl.bintray.com/jetbrains/markdown' }
+
         mavenCentral()
 
         // TODO: Remove Bintray dependencies when possible

--- a/build.gradle
+++ b/build.gradle
@@ -24,10 +24,12 @@ apply plugin: 'binary-compatibility-validator'
 String resolvedJvmTarget = System.getenv().getOrDefault('ci_java_version', JavaVersion.VERSION_1_8.toString())
 allprojects {
     repositories {
+        // TODO WORKAROUND: https://github.com/JetBrains/markdown/issues/70
+        maven { url 'https://dl.bintray.com/jetbrains/markdown' }
+
         mavenCentral()
 
         // TODO: Remove Bintray dependencies when possible
-        maven { url 'https://dl.bintray.com/jetbrains/markdown' }
         maven { url 'https://dl.bintray.com/korlibs/korlibs' }
         maven { url 'https://dl.bintray.com/kotlin/dokka' }
         maven { url 'https://dl.bintray.com/kotlin/kotlinx' }

--- a/poko-compiler-plugin/build.gradle
+++ b/poko-compiler-plugin/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 
     testImplementation project(':poko-annotations')
     testImplementation "org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlin_version"
-    testImplementation 'com.github.tschuchortdev:kotlin-compile-testing:1.3.4'
+    testImplementation 'com.github.tschuchortdev:kotlin-compile-testing:1.3.5'
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'com.google.truth:truth:1.1'
 }

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoComponentRegistrar.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoComponentRegistrar.kt
@@ -8,11 +8,8 @@ import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.codegen.extensions.ExpressionCodegenExtension
 import org.jetbrains.kotlin.com.intellij.mock.MockProject
-import org.jetbrains.kotlin.com.intellij.openapi.extensions.impl.ExtensionPointImpl
-import org.jetbrains.kotlin.com.intellij.openapi.project.Project
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
 import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.extensions.ProjectExtensionDescriptor
 import org.jetbrains.kotlin.name.FqName
 
 @AutoService(ComponentRegistrar::class)
@@ -26,20 +23,13 @@ class PokoComponentRegistrar : ComponentRegistrar {
         val messageCollector = configuration.get(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
 
         // TODO: Use ClassBuilderInterceptorExtension, ExpressionCodegenExtension, or both?
-        ExpressionCodegenExtension.registerExtensionAsFirst(
+        ExpressionCodegenExtension.registerExtension(
             project,
             PokoCodegenExtension(pokoAnnotationName, messageCollector)
         )
-        IrGenerationExtension.registerExtensionAsFirst(
+        IrGenerationExtension.registerExtension(
             project,
             PokoIrGenerationExtension(pokoAnnotationName, messageCollector)
         )
-    }
-
-    private fun <T : Any> ProjectExtensionDescriptor<T>.registerExtensionAsFirst(project: Project, extension: T) {
-        project.extensionArea
-            .getExtensionPoint(extensionPointName)
-            .let { it as ExtensionPointImpl }
-            .registerExtension(extension, project)
     }
 }

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
@@ -250,12 +250,19 @@ internal class PokoMembersTransformer(
         }
     }
 
-    // TODO: Figure out what `substituted` was supposed to be for and either fix or remove it
+    // TODO: `substituted` appears to be necessary to bind the correct parent IrFunction to the hashCodeFunctionSymbol.
+    //  Look into rewriting this from LocalClassGenerator => DeclarationGenerator.generateClassOrObjectDeclaration
+    //  => ClassGenerator.generateClass => generateAdditionalMembersForDataClass
     private fun IrBlockBodyBuilder.getHashCodeOf(property: IrProperty, irValue: IrExpression): IrExpression {
         var substituted: FunctionDescriptor? = null
         val hashCodeFunctionSymbol = getHashCodeFunction(property) {
             substituted = it
             pluginContext.symbolTable.referenceSimpleFunction(it.original)
+        }.apply {
+            if (!isBound) {
+                // TODO MISSING: Bind to correct IrFunction
+//                bind(irFunction)
+            }
         }
 
         val hasDispatchReceiver = hashCodeFunctionSymbol.descriptor.dispatchReceiverParameter != null

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
@@ -331,16 +331,16 @@ internal class PokoMembersTransformer(
             val irPropertyValue = irGetField(receiver(irFunction), property.backingField!!)
 
             val typeConstructorDescriptor = property.descriptor.type.constructor.declarationDescriptor
-            val irPropertyStringValue =
-                if (
-                    typeConstructorDescriptor is ClassDescriptor &&
-                    KotlinBuiltIns.isArrayOrPrimitiveArray(typeConstructorDescriptor)
-                )
-                    irCall(context.irBuiltIns.dataClassArrayMemberToStringSymbol, context.irBuiltIns.stringType).apply {
-                        putValueArgument(0, irPropertyValue)
-                    }
-                else
-                    irPropertyValue
+            val irPropertyStringValue = if (
+                typeConstructorDescriptor is ClassDescriptor &&
+                KotlinBuiltIns.isArrayOrPrimitiveArray(typeConstructorDescriptor)
+            ) {
+                irCall(context.irBuiltIns.dataClassArrayMemberToStringSymbol, context.irBuiltIns.stringType).apply {
+                    putValueArgument(0, irPropertyValue)
+                }
+            } else {
+                irPropertyValue
+            }
 
             irConcat.addArgument(irPropertyStringValue)
             first = false


### PR DESCRIPTION
Fixes #35.

Remove internal use of `IrPluginContext.symbolTable` which returns unbound symbols. Replace with call directly to `IrPluginContext.referenceFunctions` using `FqName` of the desired function symbol.