### PR TITLE
Fix Jetpack Compose support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
     strategy:
       matrix:
         ci_compile_mode: [ use-ir-false, use-ir-true, jetpack-compose ]
+        ci_java_version: [ 1.8, 11, 12, 13, 14, 15 ]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ jobs:
       matrix:
         ci_compile_mode: [ use-ir-false, use-ir-true, jetpack-compose ]
         ci_java_version: [ 1.8, 11, 12, 13, 14, 15 ]
+        # Compose requires Java 11:
+        exclude:
+          - ci_compile_mode: jetpack-compose
+            ci_java_version: 1.8
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,21 @@ jobs:
           java-version: ${{ matrix.ci_java_version }}
       - name: Build
         run: ./gradlew clean build --stacktrace
+
+  build-sample:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ci_compile_mode: [ use-ir-false, use-ir-true, jetpack-compose ]
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Install JDK ${{ matrix.ci_java_version }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.ci_java_version }}
       - name: Build sample
-        run: cd sample && ./gradlew build --stacktrace -Puse_ir=${{ matrix.ci_use_ir }}
+        run: cd sample && ./gradlew build --stacktrace -Pcompile_mode=${{ matrix.ci_compile_mode }}
 
 env:
   GRADLE_OPTS: >-

--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,9 @@ fabric.properties
 .gradle
 build/
 
+# Local configuration file (sdk path, etc)
+local.properties
+
 # Ignore Gradle GUI config
 gradle-app.setting
 

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <option name="RIGHT_MARGIN" value="120" />
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value />

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -10,15 +10,18 @@ buildscript {
 
     repositories {
         mavenCentral()
+        google()
     }
 
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "$publish_group:$publish_gradle_plugin_artifact"
+        classpath 'com.android.tools.build:gradle:7.0.0-alpha12'
     }
 }
 
-apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: 'dev.drewhamilton.poko'
 
 poko {
@@ -27,15 +30,44 @@ poko {
 }
 
 String resolvedJvmTarget = System.getenv().getOrDefault('ci_java_version', JavaVersion.VERSION_1_8.toString())
-project.tasks.withType(KotlinCompile.class).configureEach {
+android {
+    compileSdkVersion 30
+    buildToolsVersion '30.0.3'
+
+    defaultConfig {
+        minSdkVersion 21
+        targetSdkVersion 30
+    }
+
+    compileOptions {
+        sourceCompatibility resolvedJvmTarget
+        targetCompatibility resolvedJvmTarget
+    }
+
     kotlinOptions {
         jvmTarget = resolvedJvmTarget
         freeCompilerArgs += ['-progressive']
+    }
+
+    buildFeatures {
+        compose true
+
+        // Disable unused AGP features
+        buildConfig false
+        aidl false
+        renderScript false
+        resValues false
+        shaders false
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion compose_version
     }
 }
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "androidx.compose.runtime:runtime:$compose_version"
 
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'com.google.truth:truth:1.1'
@@ -43,6 +75,8 @@ dependencies {
 
 repositories {
     mavenCentral()
+    google()
+    jcenter()
 }
 
 boolean useIr = Boolean.parseBoolean(project.property("use_ir").toString())

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -8,23 +8,27 @@ buildscript {
         ext.set(key, val)
     }
 
+    String compileMode = project.property('compile_mode').toString()
+    boolean useCompose = compileMode == 'jetpack-compose'
     repositories {
         mavenCentral()
-        google()
+        if (useCompose) {
+            google()
+        }
     }
 
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "$publish_group:$publish_gradle_plugin_artifact"
 
-        boolean useCompose = Boolean.parseBoolean(project.property("use_compose").toString())
         if (useCompose) {
             classpath 'com.android.tools.build:gradle:7.0.0-alpha12'
         }
     }
 }
 
-boolean useCompose = Boolean.parseBoolean(project.property("use_compose").toString())
+String compileMode = project.property('compile_mode').toString()
+boolean useCompose = compileMode == 'jetpack-compose'
 if (useCompose) {
     apply plugin: 'com.android.library'
     apply plugin: 'org.jetbrains.kotlin.android'
@@ -75,7 +79,7 @@ if (useCompose) {
         }
     }
 } else {
-    boolean useIr = Boolean.parseBoolean(project.property("use_ir").toString())
+    boolean useIr = compileMode == 'use-ir-true'
     logger.lifecycle "$project: useIR = $useIr"
     project.tasks.withType(KotlinCompile.class).configureEach {
         kotlinOptions {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -22,7 +22,7 @@ buildscript {
         classpath "$publish_group:$publish_gradle_plugin_artifact"
 
         if (useCompose) {
-            classpath 'com.android.tools.build:gradle:7.0.0-alpha12'
+            classpath "com.android.tools.build:gradle:$agp_version"
         }
     }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -16,12 +16,21 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "$publish_group:$publish_gradle_plugin_artifact"
-        classpath 'com.android.tools.build:gradle:7.0.0-alpha12'
+
+        boolean useCompose = Boolean.parseBoolean(project.property("use_compose").toString())
+        if (useCompose) {
+            classpath 'com.android.tools.build:gradle:7.0.0-alpha12'
+        }
     }
 }
 
-apply plugin: 'com.android.library'
-apply plugin: 'org.jetbrains.kotlin.android'
+boolean useCompose = Boolean.parseBoolean(project.property("use_compose").toString())
+if (useCompose) {
+    apply plugin: 'com.android.library'
+    apply plugin: 'org.jetbrains.kotlin.android'
+} else {
+    apply plugin: 'org.jetbrains.kotlin.jvm'
+}
 apply plugin: 'dev.drewhamilton.poko'
 
 poko {
@@ -30,44 +39,59 @@ poko {
 }
 
 String resolvedJvmTarget = System.getenv().getOrDefault('ci_java_version', JavaVersion.VERSION_1_8.toString())
-android {
-    compileSdkVersion 30
-    buildToolsVersion '30.0.3'
+if (useCompose) {
+    android {
+        compileSdkVersion 30
+        buildToolsVersion '30.0.3'
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 30
+        defaultConfig {
+            minSdkVersion 21
+            targetSdkVersion 30
+        }
+
+        compileOptions {
+            sourceCompatibility resolvedJvmTarget
+            targetCompatibility resolvedJvmTarget
+        }
+
+        kotlinOptions {
+            jvmTarget = resolvedJvmTarget
+            freeCompilerArgs += ['-progressive']
+        }
+
+        buildFeatures {
+            compose true
+
+            // Disable unused AGP features
+            buildConfig false
+            aidl false
+            renderScript false
+            resValues false
+            shaders false
+        }
+
+        composeOptions {
+            kotlinCompilerExtensionVersion compose_version
+        }
     }
-
-    compileOptions {
-        sourceCompatibility resolvedJvmTarget
-        targetCompatibility resolvedJvmTarget
-    }
-
-    kotlinOptions {
-        jvmTarget = resolvedJvmTarget
-        freeCompilerArgs += ['-progressive']
-    }
-
-    buildFeatures {
-        compose true
-
-        // Disable unused AGP features
-        buildConfig false
-        aidl false
-        renderScript false
-        resValues false
-        shaders false
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion compose_version
+} else {
+    boolean useIr = Boolean.parseBoolean(project.property("use_ir").toString())
+    logger.lifecycle "$project: useIR = $useIr"
+    project.tasks.withType(KotlinCompile.class).configureEach {
+        kotlinOptions {
+            jvmTarget = resolvedJvmTarget
+            freeCompilerArgs += ['-progressive']
+            useIR = useIr
+        }
     }
 }
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "androidx.compose.runtime:runtime:$compose_version"
+
+    if (useCompose) {
+        implementation "androidx.compose.runtime:runtime:$compose_version"
+    }
 
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'com.google.truth:truth:1.1'
@@ -75,14 +99,8 @@ dependencies {
 
 repositories {
     mavenCentral()
-    google()
-    jcenter()
-}
-
-boolean useIr = Boolean.parseBoolean(project.property("use_ir").toString())
-logger.lifecycle "$project: useIR = $useIr"
-tasks.withType(KotlinCompile.class).configureEach {
-    kotlinOptions {
-        useIR = useIr
+    if (useCompose) {
+        google()
+        jcenter()
     }
 }

--- a/sample/gradle.properties
+++ b/sample/gradle.properties
@@ -1,5 +1,5 @@
 # Must be one of `use-ir-false`, `use-ir-true`, or `jetpack-compose`
-compile_mode=jetpack-compose
+compile_mode=use-ir-false
 
 agp_version=7.0.0-alpha12
 compose_version=1.0.0-beta03

--- a/sample/gradle.properties
+++ b/sample/gradle.properties
@@ -1,5 +1,7 @@
 # Must be one of `use-ir-false`, `use-ir-true`, or `jetpack-compose`
-compile_mode=use-ir-false
+compile_mode=jetpack-compose
+
+agp_version=7.0.0-alpha12
 compose_version=1.0.0-beta03
 
 android.useAndroidX=true

--- a/sample/gradle.properties
+++ b/sample/gradle.properties
@@ -1,4 +1,6 @@
 use_ir=true
+
+use_compose=false
 compose_version=1.0.0-beta03
 
 android.useAndroidX=true

--- a/sample/gradle.properties
+++ b/sample/gradle.properties
@@ -1,6 +1,5 @@
-use_ir=true
-
-use_compose=false
+# Must be one of `use-ir-false`, `use-ir-true`, or `jetpack-compose`
+compile_mode=use-ir-false
 compose_version=1.0.0-beta03
 
 android.useAndroidX=true

--- a/sample/gradle.properties
+++ b/sample/gradle.properties
@@ -1,1 +1,4 @@
-use_ir=false
+use_ir=true
+compose_version=1.0.0-beta03
+
+android.useAndroidX=true

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="dev.drewhamilton.poko.sample" />


### PR DESCRIPTION
Fixes another unbound symbol problem that was breaking Poko+Compose.

Also add a testing setup for Compose, since this is the second time this happened. Now we can bump the Compose and AGP versions each time either is released to verify Poko still works with Compose.