### PR TITLE
Add Java 16 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         ci_use_ir: [ true, false ]
-        ci_java_version: [ 1.8, 11, 12, 13, 14, 15 ]
+        ci_java_version: [ 1.8, 11, 12, 13, 14, 15, 16 ]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -30,7 +30,7 @@ jobs:
       matrix:
         # TODO: Re-add `jetpack-compose` mode when it supports Kotlin 1.5
         ci_compile_mode: [ use-ir-false, use-ir-true ]
-        ci_java_version: [ 1.8, 11, 12, 13, 14, 15 ]
+        ci_java_version: [ 1.8, 11, 12, 13, 14, 15, 16 ]
         # Compose requires Java 11:
         exclude:
           - ci_compile_mode: jetpack-compose

--- a/build.gradle
+++ b/build.gradle
@@ -6,12 +6,17 @@ version publish_version
 buildscript {
     repositories {
         mavenCentral()
+
+        // KSP:
+        google()
     }
 
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokka_version"
         classpath "org.jetbrains.kotlinx:binary-compatibility-validator:$binary_compatibility_validator_version"
+
+        classpath "com.google.devtools.ksp:symbol-processing-gradle-plugin:1.5.0-1.0.0-alpha09"
     }
 }
 
@@ -21,6 +26,9 @@ String resolvedJvmTarget = System.getenv().getOrDefault('ci_java_version', JavaV
 allprojects {
     repositories {
         mavenCentral()
+
+        // KSP:
+        google()
     }
 
     pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@ kotlin.code.style=official
 
 kotlin_version=1.5.0
 auto_service_version=1.0
+auto_service_ksp_version=0.5.0
 dokka_version=1.4.32
 binary_compatibility_validator_version=0.5.0
 

--- a/poko-compiler-plugin/build.gradle
+++ b/poko-compiler-plugin/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'org.jetbrains.kotlin.jvm'
-apply plugin: 'org.jetbrains.kotlin.kapt'
+apply plugin: "com.google.devtools.ksp"
 
 ext {
     artifactName = publish_compiler_plugin_artifact
@@ -13,8 +13,8 @@ dependencies {
     compileOnly "org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
-    compileOnly "com.google.auto.service:auto-service-annotations:$auto_service_version"
-    kapt "com.google.auto.service:auto-service:$auto_service_version"
+    implementation("com.google.auto.service:auto-service-annotations:$auto_service_version")
+    ksp("dev.zacsweers.autoservice:auto-service-ksp:$auto_service_ksp_version")
 
     testImplementation project(':poko-annotations')
     testImplementation "org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlin_version"

--- a/poko-gradle-plugin/build.gradle
+++ b/poko-gradle-plugin/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'java-gradle-plugin'
 apply plugin: 'org.jetbrains.kotlin.jvm'
-apply plugin: 'org.jetbrains.kotlin.kapt'
+apply plugin: "com.google.devtools.ksp"
 apply plugin: 'org.jetbrains.dokka'
 
 ext {
@@ -32,8 +32,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-gradle-plugin-api:$kotlin_version"
     compileOnly "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
-    compileOnly "com.google.auto.service:auto-service-annotations:$auto_service_version"
-    kapt "com.google.auto.service:auto-service:$auto_service_version"
+    implementation("com.google.auto.service:auto-service-annotations:$auto_service_version")
+    ksp("dev.zacsweers.autoservice:auto-service-ksp:$auto_service_ksp_version")
 
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'com.google.truth:truth:1.1.2'


### PR DESCRIPTION
Internally, use `kapt` instead of `ksp` because `kapt` doesn't work with Java 16