### PR TITLE
Re-enable Compose CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # TODO: Re-add `jetpack-compose` mode when it supports Kotlin 1.5
-        ci_compile_mode: [ use-ir-false, use-ir-true ]
+        ci_compile_mode: [ use-ir-false, use-ir-true, jetpack-compose ]
         ci_java_version: [ 1.8, 11, 12, 13, 14, 15, 16 ]
         # Compose requires Java 11:
         exclude:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,9 +1,5 @@
 # Releasing
 
-***Note**: Check if
-[Jetpack Compose supports Kotlin 1.5](https://android-review.googlesource.com/c/platform/frameworks/support/+/1651538)
-yet before releasing the next 0.8.x.*
-
  1. Make sure you're on the main branch.
  2. Change `publish_version` in gradle.properties to a non-SNAPSHOT version.
  3. Update README.md for the impending release.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,13 @@
 [versions]
 
-compose = "1.0.0-beta06"
+androidx-compose = "1.0.0-SNAPSHOT"
 kotlin = "1.5.0"
 
 [libraries]
 
 android-gradlePlugin = "com.android.tools.build:gradle:7.0.0-alpha15"
 
-androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "compose" }
+androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "androidx-compose" }
 
 autoService-annotations = { module = "com.google.auto.service:auto-service-annotations", version = "1.0" }
 autoService-ksp = { module = "dev.zacsweers.autoservice:auto-service-ksp", version = "0.5.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,13 @@
 [versions]
 
+compose = "1.0.0-beta06"
 kotlin = "1.5.0"
 
 [libraries]
 
-android-gradlePlugin = "com.android.tools.build:gradle:7.0.0-alpha14"
+android-gradlePlugin = "com.android.tools.build:gradle:7.0.0-alpha15"
 
-androidx-compose-runtime = "androidx.compose.runtime:runtime:1.0.0-beta05"
+androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "compose" }
 
 autoService-annotations = { module = "com.google.auto.service:auto-service-annotations", version = "1.0" }
 autoService-ksp = { module = "dev.zacsweers.autoservice:auto-service-ksp", version = "0.5.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ kotlin = "1.5.0"
 
 [libraries]
 
-android-gradlePlugin = "com.android.tools.build:gradle:7.0.0-alpha15"
+android-gradlePlugin = "com.android.tools.build:gradle:7.0.0-beta01"
 
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "androidx-compose" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 
 androidx-compose = "1.0.0-SNAPSHOT"
+androidx-dev-snapshot = "7377145"
 kotlin = "1.5.0"
 
 [libraries]

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -77,7 +77,7 @@ if (useCompose) {
         }
 
         composeOptions {
-            kotlinCompilerExtensionVersion libs.versions.compose.get()
+            kotlinCompilerExtensionVersion libs.versions.androidx.compose.get()
         }
     }
 } else {
@@ -105,5 +105,7 @@ repositories {
     mavenCentral()
     if (useCompose) {
         google()
+        // AndroidX snapshot repository:
+        maven { url 'https://androidx.dev/snapshots/builds/7341059/artifacts/repository' }
     }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -106,6 +106,6 @@ repositories {
     if (useCompose) {
         google()
         // AndroidX snapshot repository:
-        maven { url 'https://androidx.dev/snapshots/builds/7341059/artifacts/repository' }
+        maven { url "https://androidx.dev/snapshots/builds/7377145/artifacts/repository" }
     }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -105,7 +105,10 @@ repositories {
     mavenCentral()
     if (useCompose) {
         google()
+
         // AndroidX snapshot repository:
-        maven { url "https://androidx.dev/snapshots/builds/7377145/artifacts/repository" }
+        maven {
+            url "https://androidx.dev/snapshots/builds/${libs.versions.androidx.dev.snapshot.get()}/artifacts/repository"
+        }
     }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -77,7 +77,7 @@ if (useCompose) {
         }
 
         composeOptions {
-            kotlinCompilerExtensionVersion compose_version
+            kotlinCompilerExtensionVersion libs.versions.compose.get()
         }
     }
 } else {
@@ -94,7 +94,7 @@ if (useCompose) {
 
 dependencies {
     if (useCompose) {
-        implementation("androidx.compose.runtime:runtime:$compose_version")
+        implementation(libs.androidx.compose.runtime)
     }
 
     testImplementation(libs.junit)


### PR DESCRIPTION
Uses Compose 1.0.0-SNAPSHOT to test against a Kotlin 1.5.0-supporting version before its beta release