### PR TITLE
Run `publishAllPublications` instead of just `publishReleasePublication` during release Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [main, drew/plugin-marker]
+    branches: [main]
     tags: ['*']
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,4 +28,4 @@ jobs:
             ${{ secrets.ORG_GRADLE_PROJECT_personalSonatypeIssuesPassword }}
           ORG_GRADLE_PROJECT_personalGpgKey: ${{ secrets.ORG_GRADLE_PROJECT_personalGpgKey }}
           ORG_GRADLE_PROJECT_personalGpgPassword: ${{ secrets.ORG_GRADLE_PROJECT_personalGpgPassword }}
-        run: ./gradlew publishReleasePublicationToMavenCentralRepository
+        run: ./gradlew publishAllPublicationsToMavenCentralRepository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    branches: [main, drew/plugin-marker]
     tags: ['*']
 
 jobs:

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 
 #region Artifact info
 publish_group=dev.drewhamilton.poko
-publish_version=0.9.0-SNAPSHOT
+publish_version=0.8.1-SNAPSHOT
 
 publish_annotations_artifact=poko-annotations
 publish_compiler_plugin_artifact=poko-compiler-plugin


### PR DESCRIPTION
Fixes #54.