### PR TITLE
Kotlin 1.5.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ exclusively compatible with specific versions of Poko.
 
 | Kotlin version  | Poko version | Extra Care version |
 | --------------- | ------------ | ------------------ |
-| 1.5.0 – 1.5.20  | 0.8.1        | N/A                |
+| 1.5.0 – 1.5.21  | 0.8.1        | N/A                |
 | 1.4.30 – 1.4.32 | 0.7.4        | 0.6.0              |
 | 1.4.20 – 1.4.21 | N/A          | 0.5.0              |
 | 1.4.0 – 1.4.10  | N/A          | 0.3.1              |

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ exclusively compatible with specific versions of Poko.
 
 | Kotlin version  | Poko version | Extra Care version |
 | --------------- | ------------ | ------------------ |
-| 1.5.0 – 1.5.10  | 0.8.1        | N/A                |
+| 1.5.0 – 1.5.20  | 0.8.1        | N/A                |
 | 1.4.30 – 1.4.32 | 0.7.4        | 0.6.0              |
 | 1.4.20 – 1.4.21 | N/A          | 0.5.0              |
 | 1.4.0 – 1.4.10  | N/A          | 0.3.1              |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 androidx-compose = "1.0.0-rc01"
-kotlin = "1.5.20"
+kotlin = "1.5.21"
 
 [libraries]
 
@@ -23,6 +23,6 @@ kotlin-gradlePluginApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-a
 
 kotlinx-binaryCompatibilityValidator = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version = "0.5.0" }
 
-ksp-gradlePlugin = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version = "1.5.20-1.0.0-beta04" }
+ksp-gradlePlugin = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version = "1.5.21-1.0.0-beta05" }
 
 truth = { module = "com.google.truth:truth", version = "1.1.2" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 
-androidx-compose = "1.0.0-rc01"
+androidx-compose = "1.0.0-rc02"
 kotlin = "1.5.21"
 kotlinForCompose = "1.5.10"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 androidx-compose = "1.0.0-rc01"
-kotlin = "1.5.10"
+kotlin = "1.5.20"
 
 [libraries]
 
@@ -23,6 +23,6 @@ kotlin-gradlePluginApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-a
 
 kotlinx-binaryCompatibilityValidator = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version = "0.5.0" }
 
-ksp-gradlePlugin = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version = "1.5.10-1.0.0-beta01" }
+ksp-gradlePlugin = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version = "1.5.20-1.0.0-beta03" }
 
 truth = { module = "com.google.truth:truth", version = "1.1.2" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,6 @@ kotlin-gradlePluginApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-a
 
 kotlinx-binaryCompatibilityValidator = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version = "0.5.0" }
 
-ksp-gradlePlugin = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version = "1.5.20-1.0.0-beta03" }
+ksp-gradlePlugin = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version = "1.5.20-1.0.0-beta04" }
 
 truth = { module = "com.google.truth:truth", version = "1.1.2" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 
 androidx-compose = "1.0.0-rc01"
 kotlin = "1.5.21"
+kotlinForCompose = "1.5.10"
 
 [libraries]
 
@@ -20,6 +21,8 @@ kotlin-compileTesting = { module = "com.github.tschuchortdev:kotlin-compile-test
 kotlin-embeddableCompiler = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-gradlePluginApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }
+
+kotlinForCompose-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinForCompose" }
 
 kotlinx-binaryCompatibilityValidator = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version = "0.5.0" }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -18,11 +18,13 @@ buildscript {
     }
 
     dependencies {
-        classpath(libs.kotlin.gradlePlugin)
         classpath("$publish_group:$publish_gradle_plugin_artifact")
 
         if (useCompose) {
             classpath(libs.android.gradlePlugin)
+            classpath(libs.kotlinForCompose.gradlePlugin)
+        } else {
+            classpath(libs.kotlin.gradlePlugin)
         }
     }
 }


### PR DESCRIPTION
Also enables Jetpack Compose test builds to work when Compose's Kotlin version is lagging behind Poko's, by compiling only the Compose module with that different Kotlin version. Bumps to Compose 1.0.0-rc02.