### PR TITLE
Compose 1.0.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ kotlinForCompose = "1.5.10"
 
 [libraries]
 
-android-gradlePlugin = "com.android.tools.build:gradle:7.0.0-beta05"
+android-gradlePlugin = "com.android.tools.build:gradle:7.0.0"
 
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "androidx-compose" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 
-androidx-compose = "1.0.0-rc02"
+androidx-compose = "1.0.1"
 kotlin = "1.5.21"
-kotlinForCompose = "1.5.10"
+kotlinForCompose = "1.5.21"
 
 [libraries]
 


### PR DESCRIPTION
Update to non-beta versions of Jetpack Compose and AGP, used for testing the sample module.