### PR TITLE
Kotlin 1.6.20

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,14 @@ allprojects {
         // KSP:
         google()
 
-        // Compile testing snapshot:
-        maven { url = "https://oss.sonatype.org/content/repositories/snapshots" }
-        maven { url = "https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev" }
+        if (rootProject.snapshot_dependencies_enabled == "true") {
+            logger.lifecycle("Adding snapshots repository")
+            maven { url = "https://oss.sonatype.org/content/repositories/snapshots" }
+        }
+        if (rootProject.kotlin_dev_version_enabled == "true") {
+            logger.lifecycle("Adding Kotlin dev repository")
+            maven { url = "https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev" }
+        }
     }
 
     pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,5 +9,8 @@ publish_compiler_plugin_artifact=poko-compiler-plugin
 publish_gradle_plugin_artifact=poko-gradle-plugin
 #endregion
 
+snapshot_dependencies_enabled=false
+kotlin_dev_version_enabled=false
+
 # Workaround for https://github.com/Kotlin/dokka/issues/1405 on `./gradlew dokkaJavadoc`
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,10 @@
 [versions]
 
-androidx-compose-compiler = "1.2.0-dev-k1.6.20-RC-21f332eaa05"
-androidx-compose-runtime = "1.2.0-alpha04"
-kotlin = "1.6.20-RC"
-ksp = "1.6.20-RC-1.0.4"
+# https://androidx.dev/storage/compose-compiler/repository for versions matching new Kotlin versions:
+androidx-compose-compiler = "1.2.0-dev-k1.6.20-RC2-727605f905e"
+androidx-compose-runtime = "1.2.0-alpha07"
+kotlin = "1.6.20"
+ksp = "1.6.20-1.0.4"
 
 [libraries]
 
@@ -18,7 +19,7 @@ dokka-gradle = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "
 
 junit = { module = "junit:junit", version = "4.13.2" }
 
-kotlin-compileTesting = { module = "com.github.tschuchortdev:kotlin-compile-testing", version = "1.4.8-alpha02" }
+kotlin-compileTesting = { module = "com.github.tschuchortdev:kotlin-compile-testing", version = "1.4.8" }
 kotlin-embeddableCompiler = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-gradleApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -107,6 +107,9 @@ repositories {
     mavenCentral()
     if (useCompose) {
         google()
-        maven { url "https://androidx.dev/storage/compose-compiler/repository" }
+        if (android.composeOptions.kotlinCompilerExtensionVersion.contains("dev")) {
+            logger.lifecycle("Adding Compose compiler dev repository")
+            maven { url "https://androidx.dev/storage/compose-compiler/repository" }
+        }
     }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -62,6 +62,8 @@ if (useCompose) {
             jvmTarget = resolvedJvmTarget
             freeCompilerArgs += [
                 '-progressive',
+                "-P",
+                "plugin:androidx.compose.compiler.plugins.kotlin:suppressKotlinVersionCompatibilityCheck=true",
             ]
         }
 


### PR DESCRIPTION
Also adds simple Gradle properties to enable/disable snapshot and dev repositories

Dependencies:
* KSP 1.6.20-1.0.4

Testing dependencies:
* Compose compiler 1.2.0-dev-k1.6.20-RC2-727605f905e
* Compose runtime 1.2.0-alpha07
* Kotlin compile testing 1.4.8