### PR TITLE
Drop ci_java_version from main project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,15 @@ jobs:
     strategy:
       matrix:
         ci_use_ir: [ true, false ]
-        ci_java_version: [ 1.8, 11, 12, 13, 14, 15, 16 ]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
-      - name: Install JDK ${{ matrix.ci_java_version }}
+      - name: Install JDK
         uses: actions/setup-java@v1
         with:
-          java-version: ${{ matrix.ci_java_version }}
+          java-version: 16
       - name: Build
         run: ./gradlew clean build --stacktrace
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ buildscript {
 
 apply plugin: 'binary-compatibility-validator'
 
-String resolvedJvmTarget = System.getenv().getOrDefault('ci_java_version', JavaVersion.VERSION_1_8.toString())
 allprojects {
     repositories {
         mavenCentral()
@@ -43,7 +42,7 @@ allprojects {
     pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
         project.tasks.withType(KotlinCompile.class).configureEach {
             kotlinOptions {
-                jvmTarget = resolvedJvmTarget
+                jvmTarget = JavaVersion.VERSION_1_8.toString()
                 freeCompilerArgs += ['-progressive']
             }
         }

--- a/poko-compiler-plugin/build.gradle
+++ b/poko-compiler-plugin/build.gradle
@@ -33,3 +33,20 @@ compileTestKotlin {
         freeCompilerArgs = ["-Xinline-classes"]
     }
 }
+
+// https://jakewharton.com/build-on-latest-java-test-through-lowest-java/
+(8..15).each { javaVersion ->
+    def jdkTest = tasks.register("testJdk$javaVersion", Test) {
+        javaLauncher = javaToolchains.launcherFor {
+            languageVersion = JavaLanguageVersion.of(javaVersion)
+        }
+
+        description = "Runs the test suite on JDK $javaVersion"
+        group = LifecycleBasePlugin.VERIFICATION_GROUP
+
+        def testTask = tasks.getByName("test")
+        classpath = testTask.classpath
+        testClassesDirs = testTask.testClassesDirs
+    }
+    tasks.named("check").configure { dependsOn(jdkTest) }
+}

--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
@@ -573,20 +573,18 @@ class PokoCompilerPluginTest(
         @JvmStatic fun data(): Collection<Array<Any>> = listOf(arrayOf(true), arrayOf(false))
 
         private val compilerJvmTarget: JvmTarget by lazy {
-            val ciEnvVariable = System.getProperty("ci_java_version")
-            val resolvedJvmDescription = ciEnvVariable ?: getJavaRuntimeVersion()
-
+            val resolvedJvmDescription = getJavaRuntimeVersion()
             val resolvedJvmTarget = JvmTarget.fromString(resolvedJvmDescription)
             val default = JvmTarget.JVM_1_8
 
-            val message = when {
-                ciEnvVariable != null -> "$ciEnvVariable specified by CI environment variable"
-                resolvedJvmTarget != null -> "${resolvedJvmTarget.description} determined from test runtime JVM"
-                else -> "${default.description} because test runtime JVM version <${getJavaRuntimeVersion()}> was not valid"
+            val message = if (resolvedJvmTarget == null) {
+                "${default.description} because test runtime JVM version <$resolvedJvmDescription> was not valid"
+            } else {
+                "${resolvedJvmTarget.description} determined from test runtime JVM"
             }
             println("${PokoCompilerPluginTest::class.java.simpleName}: Using jvmTarget $message")
 
-            resolvedJvmTarget ?: JvmTarget.JVM_1_8
+            resolvedJvmTarget ?: default
         }
 
         private fun getJavaRuntimeVersion(): String {

--- a/poko-gradle-plugin/build.gradle
+++ b/poko-gradle-plugin/build.gradle
@@ -15,7 +15,6 @@ apply from: '../info.gradle'
 
 compileKotlin {
     kotlinOptions {
-        jvmTarget = System.getenv().getOrDefault('ci_java_version', JavaVersion.VERSION_1_8.toString())
         freeCompilerArgs += ['-progressive']
     }
 }


### PR DESCRIPTION
Always build with JDK 16, and test against 1.8 - 16, as outline in https://jakewharton.com/build-on-latest-java-test-through-lowest-java/

How to handle the sample project TBD.