### PR TITLE
Kotlin 1.7.0-RC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        ci_compile_mode: [ use-ir-false, use-ir-true, jetpack-compose ]
+        ci_compile_mode: [ use-ir-true, jetpack-compose ]
         ci_java_version: [ 1.8, 11, 12, 13, 14, 15, 16 ]
         # Compose requires Java 11:
         exclude:

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ publish_compiler_plugin_artifact=poko-compiler-plugin
 publish_gradle_plugin_artifact=poko-gradle-plugin
 #endregion
 
-snapshot_dependencies_enabled=false
+snapshot_dependencies_enabled=true
 kotlin_dev_version_enabled=false
 
 # Workaround for https://github.com/Kotlin/dokka/issues/1405 on `./gradlew dokkaJavadoc`

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ kotlin-embeddableCompiler = { module = "org.jetbrains.kotlin:kotlin-compiler-emb
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-gradleApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }
 
-kotlinx-binaryCompatibilityValidator = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version = "0.8.0" }
+kotlinx-binaryCompatibilityValidator = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version = "0.10.0" }
 
 ksp-gradle = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "ksp" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,8 @@
 # https://androidx.dev/storage/compose-compiler/repository for versions matching new Kotlin versions:
 androidx-compose-compiler = "1.2.0-beta02"
 androidx-compose-runtime = "1.2.0-beta02"
-kotlin = "1.6.21"
-ksp = "1.6.21-1.0.5"
+kotlin = "1.7.0-RC"
+ksp = "1.7.0-RC-1.0.5"
 
 [libraries]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@
 androidx-compose-compiler = "1.2.0-dev-k1.7.0-RC-18edd6c819e"
 androidx-compose-runtime = "1.2.0-beta02"
 kotlin = "1.7.0-RC"
+kotlinCompileTesting = "1.4.9-SNAPSHOT"
 ksp = "1.7.0-RC-1.0.5"
 
 [libraries]
@@ -19,7 +20,7 @@ dokka-gradle = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "
 
 junit = { module = "junit:junit", version = "4.13.2" }
 
-kotlin-compileTesting = { module = "com.github.tschuchortdev:kotlin-compile-testing", version = "1.4.8" }
+kotlin-compileTesting = { module = "com.github.tschuchortdev:kotlin-compile-testing", version.ref = "kotlinCompileTesting" }
 kotlin-embeddableCompiler = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-gradleApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 # https://androidx.dev/storage/compose-compiler/repository for versions matching new Kotlin versions:
-androidx-compose-compiler = "1.2.0-beta02"
+androidx-compose-compiler = "1.2.0-dev-k1.7.0-RC-18edd6c819e"
 androidx-compose-runtime = "1.2.0-beta02"
 kotlin = "1.7.0-RC"
 ksp = "1.7.0-RC-1.0.5"

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
@@ -41,7 +41,10 @@ import org.jetbrains.kotlin.ir.declarations.IrProperty
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.declarations.impl.IrValueParameterImpl
 import org.jetbrains.kotlin.ir.declarations.impl.IrVariableImpl
+import org.jetbrains.kotlin.ir.declarations.isMultiFieldValueClass
+import org.jetbrains.kotlin.ir.declarations.isSingleFieldValueClass
 import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.addArgument
 import org.jetbrains.kotlin.ir.expressions.impl.IrGetValueImpl
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
@@ -101,9 +104,9 @@ internal class PokoMembersTransformer(
             reportError("Poko does not support data classes")
             false
         }
-        isInline -> {
-            log("Inline class")
-            reportError("Poko does not support inline classes")
+        isSingleFieldValueClass || isMultiFieldValueClass -> {
+            log("Value class")
+            reportError("Poko does not support value classes")
             false
         }
         isInner -> {
@@ -164,7 +167,7 @@ internal class PokoMembersTransformer(
         val irType = irClass.defaultType
         fun irOther(): IrExpression = IrGetValueImpl(irFunction.valueParameters[0])
 
-        if (!irClass.isInline) {
+        if (!irClass.isSingleFieldValueClass) {
             +irIfThenReturnTrue(irEqeqeq(receiver(irFunction), irOther()))
         }
         +irIfThenReturnFalse(irNotIs(irOther(), irType))

--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
@@ -42,13 +42,13 @@ class PokoCompilerPluginTest(
     }
     //endregion
 
-    //region inline class
-    @Test fun `compilation of inline class fails`() {
+    //region value class
+    @Test fun `compilation of value class fails`() {
         testCompilation(
-            "illegal/Inline",
+            "illegal/Value",
             expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR
         ) { result ->
-            assertThat(result.messages).contains("Poko does not support inline classes")
+            assertThat(result.messages).contains("Poko does not support value classes")
         }
     }
     //endregion

--- a/poko-compiler-plugin/src/test/resources/illegal/Value.kt
+++ b/poko-compiler-plugin/src/test/resources/illegal/Value.kt
@@ -3,6 +3,6 @@ package illegal
 import dev.drewhamilton.poko.Poko
 
 @Suppress("unused")
-@Poko inline class Inline(
+@Poko @JvmInline value class Value(
     val id: String
 )

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -17,7 +17,6 @@ buildscript {
         mavenCentral()
         if (useCompose) {
             google()
-            maven { url "https://androidx.dev/storage/compose-compiler/repository" }
         }
     }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -87,13 +87,10 @@ if (useCompose) {
         }
     }
 } else {
-    boolean useIr = compileMode == 'use-ir-true'
-    logger.lifecycle "$project: useIR = $useIr"
     project.tasks.withType(KotlinCompile.class).configureEach {
         kotlinOptions {
             jvmTarget = resolvedJavaVersion
             freeCompilerArgs += ['-progressive']
-            useIR = useIr
         }
     }
 }

--- a/sample/gradle.properties
+++ b/sample/gradle.properties
@@ -1,4 +1,4 @@
-# Must be one of `use-ir-false`, `use-ir-true`, or `jetpack-compose`
+# Must be one of `use-ir-true`, or `jetpack-compose`
 compile_mode=jetpack-compose
 
 android.useAndroidX=true


### PR DESCRIPTION
Bumps Kotlin to 1.7.0-RC and related dependencies accordingly. Inline classes are removed, so value classes are disallowed instead.

Fixes #75.