### PR TITLE
Clean up Gradle warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 group publish_group
 version publish_version
 
@@ -22,7 +20,7 @@ buildscript {
 
 apply plugin: 'binary-compatibility-validator'
 
-allprojects {
+allprojects { project ->
     repositories {
         mavenCentral()
 
@@ -30,11 +28,11 @@ allprojects {
         google()
 
         if (rootProject.snapshot_dependencies_enabled == "true") {
-            logger.lifecycle("Adding snapshots repository")
+            logger.lifecycle("Adding snapshots repository for $project")
             maven { url = "https://oss.sonatype.org/content/repositories/snapshots" }
         }
         if (rootProject.kotlin_dev_version_enabled == "true") {
-            logger.lifecycle("Adding Kotlin dev repository")
+            logger.lifecycle("Adding Kotlin dev repository for $project")
             maven { url = "https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev" }
         }
     }
@@ -45,7 +43,7 @@ allprojects {
             sourceCompatibility = javaVersion
             targetCompatibility = javaVersion
         }
-        project.tasks.withType(KotlinCompile.class).configureEach {
+        project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
             kotlinOptions {
                 jvmTarget = javaVersion.toString()
                 freeCompilerArgs += ['-progressive']

--- a/info.gradle
+++ b/info.gradle
@@ -22,3 +22,7 @@ sourceSets {
 compileKotlin {
     dependsOn copyInfoTemplateProvider
 }
+
+ext.dependsOnCopyInfoTemplate = { taskType ->
+    project.tasks.withType(taskType) { it.dependsOn("copyInfoTemplate") }
+}

--- a/poko-compiler-plugin/build.gradle
+++ b/poko-compiler-plugin/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 
 compileKotlin {
     kotlinOptions {
-        freeCompilerArgs += ['-Xopt-in=kotlin.RequiresOptIn']
+        freeCompilerArgs += ['-opt-in=kotlin.RequiresOptIn']
     }
 }
 
@@ -50,3 +50,8 @@ compileTestKotlin {
     }
     tasks.named("check").configure { dependsOn(jdkTest) }
 }
+
+//noinspection UnnecessaryQualifiedReference
+dependsOnCopyInfoTemplate(org.jetbrains.dokka.gradle.DokkaTask)
+dependsOnCopyInfoTemplate(Jar)
+dependsOnCopyInfoTemplate(com.google.devtools.ksp.gradle.KspTask)

--- a/poko-gradle-plugin/build.gradle
+++ b/poko-gradle-plugin/build.gradle
@@ -38,3 +38,8 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.truth)
 }
+
+//noinspection UnnecessaryQualifiedReference
+dependsOnCopyInfoTemplate(org.jetbrains.dokka.gradle.DokkaTask)
+dependsOnCopyInfoTemplate(Jar)
+dependsOnCopyInfoTemplate(com.google.devtools.ksp.gradle.KspTask)

--- a/sample/jvm/build.gradle
+++ b/sample/jvm/build.gradle
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 apply plugin: "org.jetbrains.kotlin.jvm"
 apply plugin: "dev.drewhamilton.poko"
 
@@ -8,7 +6,7 @@ poko {
     enabled.set true
 }
 
-project.tasks.withType(KotlinCompile.class).configureEach {
+project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
     kotlinOptions {
         jvmTarget = kotlinJvmTarget
         freeCompilerArgs += ["-progressive"]

--- a/sample/settings.gradle
+++ b/sample/settings.gradle
@@ -27,7 +27,6 @@ if (!isCi) {
     }
 }
 
-enableFeaturePreview('VERSION_CATALOGS')
 dependencyResolutionManagement {
     versionCatalogs {
         libs {

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,5 +3,3 @@ rootProject.name = 'Poko'
 include ':poko-compiler-plugin'
 include ':poko-annotations'
 include ':poko-gradle-plugin'
-
-enableFeaturePreview('VERSION_CATALOGS')


### PR DESCRIPTION
* Remove/update deprecated Gradle features
* Avoid imports that the IDE doesn't like
* Differentiate repetitive logs
* Connect dependent tasks