### PR TITLE
Kotlin 1.7.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
 
 # https://androidx.dev/storage/compose-compiler/repository for versions matching new Kotlin versions:
-androidx-compose-compiler = "1.2.0-dev-k1.7.0-RC-4a641765aa6"
+androidx-compose-compiler = "1.2.0-dev-k1.7.0-RC2-6ab9bf980ae"
 androidx-compose-runtime = "1.2.0-beta03"
-kotlin = "1.7.0-RC2"
+kotlin = "1.7.0"
 kotlinCompileTesting = "1.4.9-SNAPSHOT"
-ksp = "1.7.0-RC-1.0.5"
+ksp = "1.7.0-RC2-1.0.5"
 
 [libraries]
 


### PR DESCRIPTION
* KSP 1.7.0-RC2-1.0.5
* Compose compiler 1.2.0-dev-k1.7.0-RC2-6ab9bf980ae

Ideally before releasing, actual 1.7.0 versions for:
- KSP
- Compose compiler
- Kotlin compile testing

Though none of these is crucial if they delay more than a few days.