### PR TITLE
Kotlin 1.8

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.8.0-Beta" />
+  </component>
+</project>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,9 +3,9 @@
 # https://androidx.dev/storage/compose-compiler/repository for versions matching new Kotlin versions:
 androidx-compose-compiler = "1.3.2"
 androidx-compose-runtime = "1.2.1"
-kotlin = "1.7.20"
+kotlin = "1.8.0-Beta"
 kotlinCompileTesting = "1.4.9"
-ksp = "1.7.20-1.0.6"
+ksp = "1.8.0-Beta-1.0.8"
 
 [libraries]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,9 +3,10 @@
 # https://androidx.dev/storage/compose-compiler/repository for versions matching new Kotlin versions:
 androidx-compose-compiler = "1.3.2"
 androidx-compose-runtime = "1.2.1"
-kotlin = "1.8.0-RC2"
+kotlin = "1.8.0"
 kotlinCompileTesting = "1.4.9"
-ksp = "1.8.0-RC-1.0.8"
+kotlinCompileTestingFork = "0.2.0"
+ksp = "1.8.0-1.0.8"
 
 [libraries]
 
@@ -21,6 +22,8 @@ dokka-gradle = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "
 junit = { module = "junit:junit", version = "4.13.2" }
 
 kotlin-compileTesting = { module = "com.github.tschuchortdev:kotlin-compile-testing", version.ref = "kotlinCompileTesting" }
+kotlin-compileTestingFork = { module = "dev.zacsweers.kctfork:core", version.ref = "kotlinCompileTestingFork" }
+
 kotlin-embeddableCompiler = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-gradleApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,9 +3,9 @@
 # https://androidx.dev/storage/compose-compiler/repository for versions matching new Kotlin versions:
 androidx-compose-compiler = "1.3.2"
 androidx-compose-runtime = "1.2.1"
-kotlin = "1.8.0-Beta"
+kotlin = "1.8.0-RC2"
 kotlinCompileTesting = "1.4.9"
-ksp = "1.8.0-Beta-1.0.8"
+ksp = "1.8.0-RC-1.0.8"
 
 [libraries]
 

--- a/poko-compiler-plugin/build.gradle
+++ b/poko-compiler-plugin/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
     testImplementation(project(':poko-annotations'))
     testImplementation(libs.kotlin.embeddableCompiler)
-    testImplementation(libs.kotlin.compileTesting)
+    testImplementation(libs.kotlin.compileTestingFork)
     testImplementation(libs.junit)
     testImplementation(libs.truth)
 }

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCommandLineProcessor.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCommandLineProcessor.kt
@@ -4,9 +4,11 @@ import com.google.auto.service.AutoService
 import org.jetbrains.kotlin.compiler.plugin.AbstractCliOption
 import org.jetbrains.kotlin.compiler.plugin.CliOption
 import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfiguration
 
 @AutoService(CommandLineProcessor::class)
+@ExperimentalCompilerApi
 class PokoCommandLineProcessor : CommandLineProcessor {
 
     override val pluginId = ArtifactInfo.COMPILER_PLUGIN_ARTIFACT

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoComponentRegistrar.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoComponentRegistrar.kt
@@ -2,15 +2,20 @@ package dev.drewhamilton.poko
 
 import com.google.auto.service.AutoService
 import dev.drewhamilton.poko.ir.PokoIrGenerationExtension
+import org.jetbrains.kotlin.backend.common.extensions.FirIncompatiblePluginAPI
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.com.intellij.mock.MockProject
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.name.FqName
 
+// TODO: implement K2 support and switch to CompilerPluginRegistrar
 @AutoService(ComponentRegistrar::class)
+@FirIncompatiblePluginAPI
+@ExperimentalCompilerApi
 class PokoComponentRegistrar : ComponentRegistrar {
 
     override fun registerProjectComponents(project: MockProject, configuration: CompilerConfiguration) {

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoIrGenerationExtension.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoIrGenerationExtension.kt
@@ -1,5 +1,6 @@
 package dev.drewhamilton.poko.ir
 
+import org.jetbrains.kotlin.backend.common.extensions.FirIncompatiblePluginAPI
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
@@ -9,6 +10,7 @@ import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.js.resolve.diagnostics.findPsi
 import org.jetbrains.kotlin.name.FqName
 
+@FirIncompatiblePluginAPI // TODO: Support FIR
 internal class PokoIrGenerationExtension(
     private val pokoAnnotationName: FqName,
     private val messageCollector: MessageCollector

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
@@ -1,6 +1,7 @@
 package dev.drewhamilton.poko.ir
 
 import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
+import org.jetbrains.kotlin.backend.common.extensions.FirIncompatiblePluginAPI
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
@@ -67,6 +68,7 @@ import org.jetbrains.kotlin.types.isNullable
 import org.jetbrains.kotlin.types.typeUtil.representativeUpperBound
 
 @OptIn(ObsoleteDescriptorBasedAPI::class)
+@FirIncompatiblePluginAPI // TODO: Support FIR
 internal class PokoMembersTransformer(
     private val annotationClass: IrClassSymbol,
     private val pluginContext: IrPluginContext,

--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
@@ -541,7 +541,7 @@ class PokoCompilerPluginTest {
         pokoAnnotationName: String,
     ) = KotlinCompilation().apply {
         workingDir = temporaryFolder.root
-        compilerPlugins = listOf<ComponentRegistrar>(PokoComponentRegistrar())
+        componentRegistrars = listOf<ComponentRegistrar>(PokoComponentRegistrar())
         inheritClassPath = true
         sources = sourceFiles.asList()
         verbose = false

--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
@@ -6,14 +6,17 @@ import com.tschuchort.compiletesting.PluginOption
 import com.tschuchort.compiletesting.SourceFile
 import java.io.File
 import java.math.BigDecimal
+import org.jetbrains.kotlin.backend.common.extensions.FirIncompatiblePluginAPI
 import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfigurationKey
 import org.jetbrains.kotlin.config.JvmTarget
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 
+@OptIn(ExperimentalCompilerApi::class)
 class PokoCompilerPluginTest {
 
     @JvmField
@@ -532,6 +535,7 @@ class PokoCompilerPluginTest {
         additionalTesting(result)
     }
 
+    @OptIn(FirIncompatiblePluginAPI::class)
     private fun prepareCompilation(
         vararg sourceFiles: SourceFile,
         pokoAnnotationName: String,


### PR DESCRIPTION
Kotlin 1.8's compiler comes with a host of new opt-in annotations, mostly related to the upcoming migration to FIR & K2. For now I've just propagated the opt-in annotations. I probably won't need to implement these changes in this PR, but I'll need to soon.