### PR TITLE
Replace `ComponentRegistrar` with `CompilerPluginRegistrar`

### DIFF
--- a/poko-compiler-plugin/api/poko-compiler-plugin.api
+++ b/poko-compiler-plugin/api/poko-compiler-plugin.api
@@ -5,8 +5,9 @@ public final class dev/drewhamilton/poko/PokoCommandLineProcessor : org/jetbrain
 	public fun processOption (Lorg/jetbrains/kotlin/compiler/plugin/AbstractCliOption;Ljava/lang/String;Lorg/jetbrains/kotlin/config/CompilerConfiguration;)V
 }
 
-public final class dev/drewhamilton/poko/PokoComponentRegistrar : org/jetbrains/kotlin/compiler/plugin/ComponentRegistrar {
+public final class dev/drewhamilton/poko/PokoCompilerPluginRegistrar : org/jetbrains/kotlin/compiler/plugin/CompilerPluginRegistrar {
 	public fun <init> ()V
-	public fun registerProjectComponents (Lorg/jetbrains/kotlin/com/intellij/mock/MockProject;Lorg/jetbrains/kotlin/config/CompilerConfiguration;)V
+	public fun getSupportsK2 ()Z
+	public fun registerExtensions (Lorg/jetbrains/kotlin/compiler/plugin/CompilerPluginRegistrar$ExtensionStorage;Lorg/jetbrains/kotlin/config/CompilerConfiguration;)V
 }
 

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCompilerPluginRegistrar.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCompilerPluginRegistrar.kt
@@ -6,19 +6,20 @@ import org.jetbrains.kotlin.backend.common.extensions.FirIncompatiblePluginAPI
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
-import org.jetbrains.kotlin.com.intellij.mock.MockProject
-import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.name.ClassId
 
-// TODO: implement K2 support and switch to CompilerPluginRegistrar
-@AutoService(ComponentRegistrar::class)
-@FirIncompatiblePluginAPI
 @ExperimentalCompilerApi
-class PokoComponentRegistrar : ComponentRegistrar {
+@FirIncompatiblePluginAPI // TODO: Support FIR
+@AutoService(CompilerPluginRegistrar::class)
+class PokoCompilerPluginRegistrar : CompilerPluginRegistrar() {
 
-    override fun registerProjectComponents(project: MockProject, configuration: CompilerConfiguration) {
+    // TODO: Support K2
+    override val supportsK2: Boolean = false
+
+    override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
         if (configuration[CompilerOptions.ENABLED] != true)
             return
 
@@ -28,7 +29,6 @@ class PokoComponentRegistrar : ComponentRegistrar {
         val messageCollector = configuration.get(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
 
         IrGenerationExtension.registerExtension(
-            project,
             PokoIrGenerationExtension(pokoAnnotationName, messageCollector)
         )
     }

--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
@@ -8,7 +8,6 @@ import java.io.File
 import java.math.BigDecimal
 import org.jetbrains.kotlin.backend.common.extensions.FirIncompatiblePluginAPI
 import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
-import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfigurationKey
 import org.jetbrains.kotlin.config.JvmTarget
@@ -541,7 +540,7 @@ class PokoCompilerPluginTest {
         pokoAnnotationName: String,
     ) = KotlinCompilation().apply {
         workingDir = temporaryFolder.root
-        componentRegistrars = listOf<ComponentRegistrar>(PokoComponentRegistrar())
+        compilerPluginRegistrars = listOf(PokoCompilerPluginRegistrar())
         inheritClassPath = true
         sources = sourceFiles.asList()
         verbose = false


### PR DESCRIPTION
One step of supporting FIR and K2.