### PR TITLE
Change annotation arg format

### DIFF
--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoComponentRegistrar.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoComponentRegistrar.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlin.com.intellij.mock.MockProject
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.ClassId
 
 // TODO: implement K2 support and switch to CompilerPluginRegistrar
 @AutoService(ComponentRegistrar::class)
@@ -22,7 +22,9 @@ class PokoComponentRegistrar : ComponentRegistrar {
         if (configuration[CompilerOptions.ENABLED] != true)
             return
 
-        val pokoAnnotationName = FqName(checkNotNull(configuration[CompilerOptions.POKO_ANNOTATION]))
+        val pokoAnnotationString = checkNotNull(configuration[CompilerOptions.POKO_ANNOTATION])
+        val pokoAnnotationClassId = ClassId.fromString(pokoAnnotationString)
+        val pokoAnnotationName = pokoAnnotationClassId.asSingleFqName()
         val messageCollector = configuration.get(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
 
         IrGenerationExtension.registerExtension(

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoIrGenerationExtension.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoIrGenerationExtension.kt
@@ -17,13 +17,12 @@ internal class PokoIrGenerationExtension(
 ) : IrGenerationExtension {
 
     override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
-        val pokoAnnotationClass = pluginContext.referenceClass(pokoAnnotationName)
-        if (pokoAnnotationClass == null) {
+        if (pluginContext.referenceClass(pokoAnnotationName) == null) {
             moduleFragment.reportError("Could not find class <$pokoAnnotationName>")
             return
         }
 
-        val pokoMembersTransformer = PokoMembersTransformer(pokoAnnotationClass, pluginContext, messageCollector)
+        val pokoMembersTransformer = PokoMembersTransformer(pokoAnnotationName, pluginContext, messageCollector)
         moduleFragment.transform(pokoMembersTransformer, null)
     }
 

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
@@ -47,7 +47,6 @@ import org.jetbrains.kotlin.ir.declarations.isSingleFieldValueClass
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.addArgument
 import org.jetbrains.kotlin.ir.expressions.impl.IrGetValueImpl
-import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.impl.IrValueParameterSymbolImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrVariableSymbolImpl
@@ -58,6 +57,7 @@ import org.jetbrains.kotlin.ir.util.hasAnnotation
 import org.jetbrains.kotlin.ir.util.isFakeOverride
 import org.jetbrains.kotlin.ir.util.primaryConstructor
 import org.jetbrains.kotlin.ir.util.properties
+import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
@@ -70,7 +70,7 @@ import org.jetbrains.kotlin.types.typeUtil.representativeUpperBound
 @OptIn(ObsoleteDescriptorBasedAPI::class)
 @FirIncompatiblePluginAPI // TODO: Support FIR
 internal class PokoMembersTransformer(
-    private val annotationClass: IrClassSymbol,
+    private val pokoAnnotationName: FqName,
     private val pluginContext: IrPluginContext,
     private val messageCollector: MessageCollector,
 ) : IrElementTransformerVoidWithContext() {
@@ -97,7 +97,7 @@ internal class PokoMembersTransformer(
     }
 
     private fun IrClass.isPokoClass(): Boolean = when {
-        !hasAnnotation(annotationClass) -> {
+        !hasAnnotation(pokoAnnotationName) -> {
             log("Not Poko class")
             false
         }

--- a/poko-gradle-plugin/src/main/kotlin/dev/drewhamilton/poko/gradle/Annotations.kt
+++ b/poko-gradle-plugin/src/main/kotlin/dev/drewhamilton/poko/gradle/Annotations.kt
@@ -1,4 +1,3 @@
 package dev.drewhamilton.poko.gradle
 
 internal const val DEFAULT_POKO_ANNOTATION = "dev.drewhamilton.poko.Poko"
-internal const val LEGACY_DATA_API_ANNOTATION = "dev.drewhamilton.extracare.DataApi"

--- a/poko-gradle-plugin/src/main/kotlin/dev/drewhamilton/poko/gradle/Annotations.kt
+++ b/poko-gradle-plugin/src/main/kotlin/dev/drewhamilton/poko/gradle/Annotations.kt
@@ -1,3 +1,3 @@
 package dev.drewhamilton.poko.gradle
 
-internal const val DEFAULT_POKO_ANNOTATION = "dev.drewhamilton.poko.Poko"
+internal const val DEFAULT_POKO_ANNOTATION = "dev/drewhamilton/poko/Poko"

--- a/poko-gradle-plugin/src/main/kotlin/dev/drewhamilton/poko/gradle/PokoGradlePlugin.kt
+++ b/poko-gradle-plugin/src/main/kotlin/dev/drewhamilton/poko/gradle/PokoGradlePlugin.kt
@@ -43,7 +43,7 @@ class PokoGradlePlugin : KotlinCompilerPluginSupportPlugin {
         return project.provider {
             listOf(
                 SubpluginOption(key = "enabled", value = extension.enabled.get().toString()),
-                SubpluginOption(key = "pokoAnnotation", value = extension.pokoAnnotation.get().toString()),
+                SubpluginOption(key = "pokoAnnotation", value = extension.pokoAnnotation.get()),
             )
         }
     }

--- a/poko-gradle-plugin/src/main/kotlin/dev/drewhamilton/poko/gradle/PokoGradlePlugin.kt
+++ b/poko-gradle-plugin/src/main/kotlin/dev/drewhamilton/poko/gradle/PokoGradlePlugin.kt
@@ -34,7 +34,6 @@ class PokoGradlePlugin : KotlinCompilerPluginSupportPlugin {
 
         val annotationDependency = when (extension.pokoAnnotation.get()) {
             DEFAULT_POKO_ANNOTATION -> ArtifactInfo.annotationsDependency
-            LEGACY_DATA_API_ANNOTATION -> "dev.drewhamilton.extracare:data-api-annotations:0.6.0"
             else -> null
         }
         if (annotationDependency != null) {

--- a/poko-gradle-plugin/src/main/kotlin/dev/drewhamilton/poko/gradle/PokoPluginExtension.kt
+++ b/poko-gradle-plugin/src/main/kotlin/dev/drewhamilton/poko/gradle/PokoPluginExtension.kt
@@ -1,14 +1,21 @@
 package dev.drewhamilton.poko.gradle
 
+import javax.inject.Inject
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
-import javax.inject.Inject
 
 abstract class PokoPluginExtension @Inject constructor(objects: ObjectFactory) {
 
     val enabled: Property<Boolean> = objects.property(Boolean::class.javaObjectType)
         .convention(true)
 
+    /**
+     * Define a custom Poko marker annotation. The poko-annotations artifact won't be automatically
+     * added as a dependency if a different annotation is defined.
+     *
+     * Note that this must be in the format of a string where packages are delimited by `/` and
+     * classes by `.`, e.g. `com/example/Nested.Annotation`.
+     */
     val pokoAnnotation: Property<String> = objects.property(String::class.java)
         .convention(DEFAULT_POKO_ANNOTATION)
 }


### PR DESCRIPTION
The annotation used to denote Poko classes can be customized. This changes the format of the input string, using `/` rather than `.` to denote nested package names.

For consumers,
```groovy
pokoAnnotation.set "com.example.OuterClass.InnerAnnotation"
```

changes to
```groovy
pokoAnnotation.set "com/example/OuterClass.InnerAnnotation"
```


This also removes automatically adding the legacy `DataApi` dependency – consumers will have to add it manually if using it.