### PR TITLE
Kotlin Compile Testing 1.5.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 androidx-compose-compiler = "1.4.1"
 androidx-compose-runtime = "1.3.3"
 kotlin = "1.8.0"
-kotlinCompileTesting = "1.4.9"
+kotlinCompileTesting = "1.5.0"
 kotlinCompileTestingFork = "0.2.0"
 ksp = "1.8.0-1.0.9"
 

--- a/poko-compiler-plugin/build.gradle.kts
+++ b/poko-compiler-plugin/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
 
     testImplementation(project(":poko-annotations"))
     testImplementation(libs.kotlin.embeddableCompiler)
-    testImplementation(libs.kotlin.compileTestingFork)
+    testImplementation(libs.kotlin.compileTesting)
     testImplementation(libs.junit)
     testImplementation(libs.truth)
 }


### PR DESCRIPTION
Switches back to the non-fork now that it supports Kotlin 1.8