### PR TITLE
Fix CI warnings for `PokoSample:compose`

### DIFF
--- a/sample/compose/build.gradle.kts
+++ b/sample/compose/build.gradle.kts
@@ -22,6 +22,7 @@ if (jvmToolchainLanguageVersion != null) {
 }
 
 android {
+    namespace = "dev.drewhamilton.poko.sample.compose"
     compileSdkVersion(32)
 
     defaultConfig {

--- a/sample/compose/build.gradle.kts
+++ b/sample/compose/build.gradle.kts
@@ -29,11 +29,10 @@ android {
         minSdk = 21
     }
 
-    if (jvmToolchainLanguageVersion == null) {
-        compileOptions {
-            sourceCompatibility(resolvedJavaVersion)
-            targetCompatibility(resolvedJavaVersion)
-        }
+    // TODO: Wrap in `if(jvmToolchainLanguageVersion == null)` from AGP 8.1
+    compileOptions {
+        sourceCompatibility(resolvedJavaVersion)
+        targetCompatibility(resolvedJavaVersion)
     }
 
     kotlinOptions {

--- a/sample/compose/build.gradle.kts
+++ b/sample/compose/build.gradle.kts
@@ -37,11 +37,7 @@ android {
     }
 
     kotlinOptions {
-        freeCompilerArgs = listOf(
-            "-progressive",
-            "-P",
-            "plugin:androidx.compose.compiler.plugins.kotlin:suppressKotlinVersionCompatibilityCheck=true",
-        )
+        freeCompilerArgs = listOf("-progressive")
     }
 
     @Suppress("UnstableApiUsage")

--- a/sample/compose/build.gradle.kts
+++ b/sample/compose/build.gradle.kts
@@ -23,11 +23,10 @@ if (jvmToolchainLanguageVersion != null) {
 
 android {
     namespace = "dev.drewhamilton.poko.sample.compose"
-    compileSdkVersion(32)
+    compileSdk = 33
 
     defaultConfig {
-        minSdkVersion(21)
-        targetSdkVersion(32)
+        minSdk = 21
     }
 
     if (jvmToolchainLanguageVersion == null) {
@@ -45,6 +44,7 @@ android {
         )
     }
 
+    @Suppress("UnstableApiUsage")
     buildFeatures {
         compose = true
 
@@ -56,6 +56,7 @@ android {
         shaders = false
     }
 
+    @Suppress("UnstableApiUsage")
     composeOptions {
         kotlinCompilerExtensionVersion = libs.versions.androidx.compose.compiler.get()
     }
@@ -70,6 +71,7 @@ dependencies {
 
 repositories {
     google()
+    @Suppress("UnstableApiUsage")
     if (android.composeOptions.kotlinCompilerExtensionVersion!!.contains("dev")) {
         logger.lifecycle("Adding Compose compiler dev repository")
         maven { url = uri("https://androidx.dev/storage/compose-compiler/repository") }

--- a/sample/compose/src/main/AndroidManifest.xml
+++ b/sample/compose/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="dev.drewhamilton.poko.sample.compose" />


### PR DESCRIPTION
* Update `PokoSample:compose` AGP-related syntax
* Fix mismatch in `PokoSample:compose` javac/kotlinc targets due to AGP bug