### PR TITLE
Renovate: Ignore Kotlin packages with unsupported versions

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -16,5 +16,10 @@
         "org.jetbrains.kotlinx:binary-compatibility-validator",
       ],
     },
-  ]
+  ],
+  "ignoreDeps": [
+    "org.jetbrains.kotlin:kotlin-compiler-embeddable",
+    "org.jetbrains.kotlin:kotlin-gradle-plugin",
+    "org.jetbrains.kotlin:kotlin-gradle-plugin-api",
+  ],
 }


### PR DESCRIPTION
As visible in #104, Renovate provides strange versions for these 3 packages. They should be lined up with the shared `kotlin` version, so ignoring them should produce the desired behavior from Renovate.