### PR TITLE
Move `@ObsoleteDescriptorBasedAPI` opt-in to specific call sites

### DIFF
--- a/.idea/kotlinScripting.xml
+++ b/.idea/kotlinScripting.xml
@@ -3,7 +3,6 @@
   <component name="KotlinScriptingSettings">
     <scriptDefinition className="org.jetbrains.kotlin.scripting.resolve.KotlinScriptDefinitionFromAnnotatedTemplate" definitionName="KotlinBuildScript">
       <order>2147483647</order>
-      <autoReloadConfigurations>true</autoReloadConfigurations>
     </scriptDefinition>
   </component>
 </project>


### PR DESCRIPTION
I think these calls won't be compatible with K2. This makes sure more aren't added under the class-level opt-in, and gives context for why they're used in each case.