### PR TITLE
Try different JDK 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
           java-version: |
             8
             9
-            10
             11
             12
             13
@@ -30,6 +29,12 @@ jobs:
             17
             18
             19
+      # Zulu JDK 10 seems to be flaky on GH Actions:
+      - name: Install JDK 10
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 10
       - name: Build
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,12 @@ jobs:
         uses: actions/checkout@v3
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
+      # Zulu JDK 10 seems to be flaky on GH Actions:
+      - name: Install JDK 10
+        uses: actions/setup-java@v3
+        with:
+          distribution: liberica
+          java-version: 10
       - name: Install JDK
         uses: actions/setup-java@v3
         with:
@@ -29,12 +35,6 @@ jobs:
             17
             18
             19
-      # Zulu JDK 10 seems to be flaky on GH Actions:
-      - name: Install JDK 10
-        uses: actions/setup-java@v3
-        with:
-          distribution: liberica
-          java-version: 10
       - name: Build
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install JDK 10
         uses: actions/setup-java@v3
         with:
-          distribution: temurin
+          distribution: liberica
           java-version: 10
       - name: Build
         uses: gradle/gradle-build-action@v2


### PR DESCRIPTION
CI tests with JDK have been flaky for some time, so I'm trying a different distribution to see if it's a distribution-specific bug. I'll have to rerun the build several times to see whether it flakes.