### PR TITLE
Skip testJdk10 on CI

### DIFF
--- a/poko-compiler-plugin/build.gradle.kts
+++ b/poko-compiler-plugin/build.gradle.kts
@@ -58,5 +58,11 @@ for (javaVersion in 8..18) {
         classpath = testTask.classpath
         testClassesDirs = testTask.testClassesDirs
     }
+
+    // JDK 10 is flaky on CI:
+    val isCi = System.getenv()["CI"] == "true"
+    if (isCi && javaVersion == 10)
+        continue
+
     tasks.named("check").configure { dependsOn(jdkTest) }
 }


### PR DESCRIPTION
It's been super flaky for awhile now. Flakiness is not dependent on JDK distribution: see #149.