### PR TITLE
Update annotation name referenced in array content error message

### DIFF
--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
@@ -216,7 +216,7 @@ internal class PokoMembersTransformer(
         // TODO: Handle property of type `Any?` that is an array at runtime
         if (!propertyClassifier.isArrayOrPrimitiveArray(context)) {
             irProperty.reportError(
-                "@ReadArrayContent on property of type <${irProperty.type.render()}> not supported"
+                "@ArrayContentBased on property of type <${irProperty.type.render()}> not supported"
             )
             return irEquals(receiver, argument)
         }
@@ -368,7 +368,7 @@ internal class PokoMembersTransformer(
         // TODO: Handle property of type `Any?` that is an array at runtime
         if (!propertyClassifier.isArrayOrPrimitiveArray(context)) {
             irProperty.reportError(
-                "@ReadArrayContent on property of type <${irProperty.type.render()}> not supported"
+                "@ArrayContentBased on property of type <${irProperty.type.render()}> not supported"
             )
             return null
         }
@@ -492,7 +492,7 @@ internal class PokoMembersTransformer(
         // TODO: Handle property of type `Any?` that is an array at runtime
         if (!propertyClassifier.isArrayOrPrimitiveArray(context)) {
             irProperty.reportError(
-                "@ReadArrayContent on property of type <${irProperty.type.render()}> not supported"
+                "@ArrayContentBased on property of type <${irProperty.type.render()}> not supported"
             )
             return null
         }

--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
@@ -646,7 +646,7 @@ class PokoCompilerPluginTest {
             expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR
         ) { result ->
             assertThat(result.messages)
-                .contains("@ReadArrayContent on property of type <kotlin.Any?> not supported")
+                .contains("@ArrayContentBased on property of type <kotlin.Any?> not supported")
         }
     }
 
@@ -656,7 +656,7 @@ class PokoCompilerPluginTest {
             expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR
         ) { result ->
             assertThat(result.messages)
-                .contains("@ReadArrayContent on property of type <G of illegal.GenericArrayHolder> not supported")
+                .contains("@ArrayContentBased on property of type <G of illegal.GenericArrayHolder> not supported")
         }
     }
 
@@ -666,11 +666,11 @@ class PokoCompilerPluginTest {
             expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR
         ) { result ->
             assertThat(result.messages)
-                .contains("@ReadArrayContent on property of type <kotlin.String> not supported")
+                .contains("@ArrayContentBased on property of type <kotlin.String> not supported")
             assertThat(result.messages)
-                .contains("@ReadArrayContent on property of type <kotlin.Int> not supported")
+                .contains("@ArrayContentBased on property of type <kotlin.Int> not supported")
             assertThat(result.messages)
-                .contains("@ReadArrayContent on property of type <kotlin.Float> not supported")
+                .contains("@ArrayContentBased on property of type <kotlin.Float> not supported")
         }
     }
     //endregion


### PR DESCRIPTION
Had stale string references to `@ReadArrayContent`; annotation is now named `@ArrayContentBased`.