### PR TITLE
Drew/arrays/runtime typed array support

### DIFF
--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
@@ -222,7 +222,7 @@ internal class PokoMembersTransformer(
         if (!propertyClassifier.isArrayOrPrimitiveArray(context)) {
             // TODO: Handle generic type that is an array at runtime
             return if (propertyClassifier == context.irBuiltIns.anyClass) {
-                irRuntimeArrayContentDeepEquals(receiver, argument, propertyClassifier)
+                irRuntimeArrayContentDeepEquals(receiver, argument)
             } else {
                 irProperty.reportError(
                     "@ArrayContentBased on property of type <${propertyType.render()}> not supported"
@@ -245,7 +245,6 @@ internal class PokoMembersTransformer(
     private fun IrBuilderWithScope.irRuntimeArrayContentDeepEquals(
         receiver: IrExpression,
         argument: IrExpression,
-        propertyClassifier: IrClassifierSymbol,
     ): IrExpression {
         val starArrayType = context.irBuiltIns.arrayClass.createType(
             hasQuestionMark = false,
@@ -283,6 +282,7 @@ internal class PokoMembersTransformer(
                         },
                     ),
                 ),
+                // TODO: Primitive arrays
                 irElseBranch(
                     irIfThenReturnFalse(irNotEquals(receiver, argument)),
                 ),
@@ -290,6 +290,10 @@ internal class PokoMembersTransformer(
         )
     }
 
+    /**
+     * Finds `contentDeepEquals` function if [propertyClassifier] is a typed array, or
+     * `contentEquals` function if it is a primitive array.
+     */
     private fun IrBuilderWithScope.findContentDeepEqualsFunctionSymbol(
         propertyClassifier: IrClassifierSymbol,
     ): IrSimpleFunctionSymbol {

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
@@ -355,12 +355,7 @@ internal class PokoMembersTransformer(
         +irResultVar
 
         for (property in irProperties.drop(1)) {
-            val shiftedResult = irCallOp(
-                callee = context.irBuiltIns.intTimesSymbol,
-                type = irIntType,
-                dispatchReceiver = irGet(irResultVar),
-                argument = irInt(31),
-            )
+            val shiftedResult = irCallOp(context.irBuiltIns.intTimesSymbol, irIntType, irGet(irResultVar), irInt(31),)
             val irRhs = irCallOp(context.irBuiltIns.intPlusSymbol, irIntType, shiftedResult, getHashCodeOfProperty(irFunction, property))
             +irSet(irResultVar.symbol, irRhs)
         }

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
@@ -251,51 +251,44 @@ internal class PokoMembersTransformer(
             hasQuestionMark = false,
             arguments = listOf(IrStarProjectionImpl),
         )
-        return irComposite {
-            +irWhen(
-                type = context.irBuiltIns.unitType,
-                branches = listOf(
-                    irBranch(
-                        condition = irIs(
-                            argument = receiver,
-                            type = starArrayType,
-                        ),
-                        result = irIfThenReturnFalse(
-                            irCall(
-                                callee = context.irBuiltIns.ororSymbol,
+        return irWhen(
+            type = context.irBuiltIns.booleanType,
+            branches = listOf(
+                irBranch(
+                    condition = irIs(
+                        argument = receiver,
+                        type = starArrayType,
+                    ),
+                    result = irCall(
+                        callee = context.irBuiltIns.andandSymbol,
+                        type = context.irBuiltIns.booleanType,
+                        valueArgumentsCount = 2,
+                    ).apply {
+                        putValueArgument(0, irIs(argument, starArrayType))
+                        putValueArgument(
+                            index = 1,
+                            valueArgument = irCall(
+                                callee = findContentDeepEqualsFunctionSymbol(
+                                    context.irBuiltIns.arrayClass,
+                                ),
                                 type = context.irBuiltIns.booleanType,
-                                valueArgumentsCount = 2,
+                                valueArgumentsCount = 1,
+                                typeArgumentsCount = 1,
                             ).apply {
-                                putValueArgument(0, irNotIs(argument, starArrayType))
-                                putValueArgument(
-                                    index = 1,
-                                    valueArgument = irNot(
-                                        irCall(
-                                            callee = findContentDeepEqualsFunctionSymbol(
-                                                context.irBuiltIns.arrayClass,
-                                            ),
-                                            type = context.irBuiltIns.booleanType,
-                                            valueArgumentsCount = 1,
-                                            typeArgumentsCount = 1,
-                                        ).apply {
-                                            extensionReceiver = receiver
-                                            putValueArgument(0, argument)
-                                        }
-                                    )
-                                )
-                            },
-                        ),
-                    ),
-
-                    // TODO: Primitive arrays
-
-                    irElseBranch(
-                        irIfThenReturnFalse(irNotEquals(receiver, argument)),
-                    ),
+                                extensionReceiver = receiver
+                                putValueArgument(0, argument)
+                            }
+                        )
+                    },
                 ),
-            )
-            +irReturnTrue()
-        }
+
+                // TODO: Primitive arrays
+
+                irElseBranch(
+                    irEquals(receiver, argument),
+                ),
+            ),
+        )
     }
 
     /**

--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
@@ -640,13 +640,22 @@ class PokoCompilerPluginTest {
         compare = compare,
     )
 
-    @Test fun `compilation reading array content of type Any fails`() {
-        testCompilation(
-            "illegal/AnyArrayHolder",
-            expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR
-        ) { result ->
-            assertThat(result.messages)
-                .contains("@ArrayContentBased on property of type <kotlin.Any?> not supported")
+    @Test fun `two AnyArrayHolder instances holding equivalent typed arrays are equals`() {
+        compareAnyArrayHolderApiInstances { firstInstance, secondInstance ->
+            assertThat(firstInstance).isEqualTo(secondInstance)
+            assertThat(secondInstance).isEqualTo(firstInstance)
+        }
+    }
+
+    @Test fun `two AnyArrayHolder instances holding equivalent typed arrays have same hashCode`() {
+        compareAnyArrayHolderApiInstances { firstInstance, secondInstance ->
+            assertThat(firstInstance.hashCode()).isEqualTo(secondInstance.hashCode())
+        }
+    }
+
+    @Test fun `two AnyArrayHolder instances holding equivalent typed arrays have same toString`() {
+        compareAnyArrayHolderApiInstances { firstInstance, secondInstance ->
+            assertThat(firstInstance.toString()).isEqualTo(secondInstance.toString())
         }
     }
 
@@ -659,6 +668,25 @@ class PokoCompilerPluginTest {
                 .contains("@ArrayContentBased on property of type <G of illegal.GenericArrayHolder> not supported")
         }
     }
+
+    private fun compareAnyArrayHolderApiInstances(
+        any1: Any = arrayOf("string A", "string B"),
+        nullableAny1: Any? = null,
+        any2: Any = arrayOf("string A", "string B"),
+        nullableAny2: Any? = null,
+        compare: (firstInstance: Any, secondInstance: Any) -> Unit,
+    ) = compareTwoInstances(
+        sourceFileName = "api/AnyArrayHolder",
+        firstInstanceConstructorArgs = listOf(
+            Any::class.java to any1,
+            Any::class.java to nullableAny1,
+        ),
+        secondInstanceConstructorArgs = listOf(
+            Any::class.java to any2,
+            Any::class.java to nullableAny2,
+        ),
+        compare = compare,
+    )
 
     @Test fun `compilation reading array content of non-arrays fails`() {
         testCompilation(

--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
@@ -741,6 +741,16 @@ class PokoCompilerPluginTest {
         }
     }
 
+    @Test fun `AnyArrayHolder instances holding inequivalent trailing properties are not equals`() {
+        compareAnyArrayHolderApiInstances(
+            trailingProperty1 = "1",
+            trailingProperty2 = "2",
+        ) { firstInstance, secondInstance ->
+            assertThat(firstInstance).isNotEqualTo(secondInstance)
+            assertThat(secondInstance).isNotEqualTo(firstInstance)
+        }
+    }
+
     @Test fun `compilation reading array content of generic type fails`() {
         testCompilation(
             "illegal/GenericArrayHolder",
@@ -754,18 +764,22 @@ class PokoCompilerPluginTest {
     private fun compareAnyArrayHolderApiInstances(
         any1: Any = arrayOf("string A", "string B"),
         nullableAny1: Any? = null,
+        trailingProperty1: String = "trailing string",
         any2: Any = arrayOf("string A", "string B"),
         nullableAny2: Any? = null,
+        trailingProperty2: String = trailingProperty1,
         compare: (firstInstance: Any, secondInstance: Any) -> Unit,
     ) = compareTwoInstances(
         sourceFileName = "api/AnyArrayHolder",
         firstInstanceConstructorArgs = listOf(
             Any::class.java to any1,
             Any::class.java to nullableAny1,
+            String::class.java to trailingProperty1,
         ),
         secondInstanceConstructorArgs = listOf(
             Any::class.java to any2,
             Any::class.java to nullableAny2,
+            String::class.java to trailingProperty2,
         ),
         compare = compare,
     )
@@ -790,6 +804,7 @@ class PokoCompilerPluginTest {
             constructorArgs = listOf(
                 Any::class.java to arrayOf(1, 2L, 3f, 4.0),
                 Any::class.java to arrayOf(1, 2L, 3f, 4.0),
+                String::class.java to "trailing",
             ),
         ) { apiInstance, dataInstance ->
             assertThat(apiInstance.hashCode()).isEqualTo(dataInstance.hashCode())
@@ -802,6 +817,7 @@ class PokoCompilerPluginTest {
             constructorArgs = listOf(
                 Any::class.java to arrayOf(1, 2L, 3f, 4.0),
                 Any::class.java to arrayOf(1, 2L, 3f, 4.0),
+                String::class.java to "trailing",
             ),
         ) { apiInstance, dataInstance ->
             assertThat(apiInstance.toString()).isEqualTo(dataInstance.toString())

--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
@@ -783,6 +783,30 @@ class PokoCompilerPluginTest {
                 .contains("@ArrayContentBased on property of type <kotlin.Float> not supported")
         }
     }
+
+    @Test fun `AnyArrayHolder has same hashCode as handwritten implementation`() {
+        compareApiWithDataClass(
+            sourceFileName = "AnyArrayHolder",
+            constructorArgs = listOf(
+                Any::class.java to arrayOf(1, 2L, 3f, 4.0),
+                Any::class.java to arrayOf(1, 2L, 3f, 4.0),
+            ),
+        ) { apiInstance, dataInstance ->
+            assertThat(apiInstance.hashCode()).isEqualTo(dataInstance.hashCode())
+        }
+    }
+
+    @Test fun `AnyArrayHolder has same toString as handwritten implementation`() {
+        compareApiWithDataClass(
+            sourceFileName = "AnyArrayHolder",
+            constructorArgs = listOf(
+                Any::class.java to arrayOf(1, 2L, 3f, 4.0),
+                Any::class.java to arrayOf(1, 2L, 3f, 4.0),
+            ),
+        ) { apiInstance, dataInstance ->
+            assertThat(apiInstance.toString()).isEqualTo(dataInstance.toString())
+        }
+    }
     //endregion
 
     //region Unknown annotation name

--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
@@ -659,6 +659,88 @@ class PokoCompilerPluginTest {
         }
     }
 
+    @Test fun `two AnyArrayHolder instances holding equivalent nested typed arrays are equals`() {
+        compareAnyArrayHolderApiInstances(
+            any1 = arrayOf(arrayOf("xx", "xy"), arrayOf("yx", "yy")),
+            any2 = arrayOf(arrayOf("xx", "xy"), arrayOf("yx", "yy")),
+            nullableAny1 = arrayOf(arrayOf(1L, 2f), arrayOf(3.0, 4)),
+            nullableAny2 = arrayOf(arrayOf(1L, 2f), arrayOf(3.0, 4)),
+        ) { firstInstance, secondInstance ->
+            assertThat(firstInstance).isEqualTo(secondInstance)
+            assertThat(secondInstance).isEqualTo(firstInstance)
+        }
+    }
+
+    @Test fun `two AnyArrayHolder instances holding equivalent nested typed arrays have same hashCode`() {
+        compareAnyArrayHolderApiInstances(
+            any1 = arrayOf(arrayOf("xx", "xy"), arrayOf("yx", "yy")),
+            any2 = arrayOf(arrayOf("xx", "xy"), arrayOf("yx", "yy")),
+            nullableAny1 = arrayOf(arrayOf(1L, 2f), arrayOf(3.0, 4)),
+            nullableAny2 = arrayOf(arrayOf(1L, 2f), arrayOf(3.0, 4)),
+        ) { firstInstance, secondInstance ->
+            assertThat(firstInstance.hashCode()).isEqualTo(secondInstance.hashCode())
+        }
+    }
+
+    @Test fun `two AnyArrayHolder instances holding equivalent nested typed arrays have same toString`() {
+        compareAnyArrayHolderApiInstances(
+            any1 = arrayOf(arrayOf("xx", "xy"), arrayOf("yx", "yy")),
+            any2 = arrayOf(arrayOf("xx", "xy"), arrayOf("yx", "yy")),
+            nullableAny1 = arrayOf(arrayOf(1L, 2f), arrayOf(3.0, 4)),
+            nullableAny2 = arrayOf(arrayOf(1L, 2f), arrayOf(3.0, 4)),
+        ) { firstInstance, secondInstance ->
+            assertThat(firstInstance.toString()).isEqualTo(secondInstance.toString())
+        }
+    }
+
+    @Test fun `two AnyArrayHolder instances holding equivalent non-arrays are equals`() {
+        compareAnyArrayHolderApiInstances(
+            any1 = listOf("one", "two"),
+            any2 = listOf("one", "two"),
+        ) { firstInstance, secondInstance ->
+            assertThat(firstInstance).isEqualTo(secondInstance)
+            assertThat(secondInstance).isEqualTo(firstInstance)
+        }
+    }
+
+    @Test fun `two AnyArrayHolder instances holding equivalent non-arrays have same hashCode`() {
+        compareAnyArrayHolderApiInstances(
+            any1 = listOf("one", "two"),
+            any2 = listOf("one", "two"),
+        ) { firstInstance, secondInstance ->
+            assertThat(firstInstance.hashCode()).isEqualTo(secondInstance.hashCode())
+        }
+    }
+
+    @Test fun `two AnyArrayHolder instances holding equivalent non-arrays have same toString`() {
+        compareAnyArrayHolderApiInstances(
+            any1 = listOf("one", "two"),
+            any2 = listOf("one", "two"),
+        ) { firstInstance, secondInstance ->
+            assertThat(firstInstance.toString()).isEqualTo(secondInstance.toString())
+        }
+    }
+
+    @Test fun `two AnyArrayHolder instances holding inequivalent nested typed arrays are not equals`() {
+        compareAnyArrayHolderApiInstances(
+            any1 = arrayOf(arrayOf("xx", "xy"), arrayOf("yx", "yy")),
+            any2 = arrayOf(arrayOf(1L, 2f), arrayOf(3.0, 4)),
+        ) { firstInstance, secondInstance ->
+            assertThat(firstInstance).isNotEqualTo(secondInstance)
+            assertThat(secondInstance).isNotEqualTo(firstInstance)
+        }
+    }
+
+    @Test fun `AnyArrayHolder instances holding mismatching types are not equals`() {
+        compareAnyArrayHolderApiInstances(
+            any1 = arrayOf("x", "y"),
+            any2 = "xy",
+        ) { firstInstance, secondInstance ->
+            assertThat(firstInstance).isNotEqualTo(secondInstance)
+            assertThat(secondInstance).isNotEqualTo(firstInstance)
+        }
+    }
+
     @Test fun `compilation reading array content of generic type fails`() {
         testCompilation(
             "illegal/GenericArrayHolder",

--- a/poko-compiler-plugin/src/test/resources/api/AnyArrayHolder.kt
+++ b/poko-compiler-plugin/src/test/resources/api/AnyArrayHolder.kt
@@ -9,4 +9,5 @@ import dev.drewhamilton.poko.Poko
 @Poko class AnyArrayHolder(
     @ArrayContentBased val any: Any,
     @ArrayContentBased val nullableAny: Any?,
+    val trailingProperty: String,
 )

--- a/poko-compiler-plugin/src/test/resources/api/AnyArrayHolder.kt
+++ b/poko-compiler-plugin/src/test/resources/api/AnyArrayHolder.kt
@@ -1,4 +1,4 @@
-package illegal
+package api
 
 import dev.drewhamilton.poko.ArrayContentBased
 import dev.drewhamilton.poko.ExperimentalArrayContentSupport
@@ -7,5 +7,6 @@ import dev.drewhamilton.poko.Poko
 @Suppress("Unused")
 @OptIn(ExperimentalArrayContentSupport::class)
 @Poko class AnyArrayHolder(
-    @ArrayContentBased val any: Any?,
+    @ArrayContentBased val any: Any,
+    @ArrayContentBased val nullableAny: Any?,
 )

--- a/poko-compiler-plugin/src/test/resources/data/AnyArrayHolder.kt
+++ b/poko-compiler-plugin/src/test/resources/data/AnyArrayHolder.kt
@@ -1,0 +1,155 @@
+package data
+
+/**
+ * Data classes don't implement array content checks, so [equals], [hashCode], and [toString] must
+ * be written by hand.
+ */
+@Suppress("Unused")
+data class AnyArrayHolder(
+    val any: Any,
+    val nullableAny: Any?,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other)
+            return true
+
+        if (other !is AnyArrayHolder)
+            return false
+
+        when (this.any) {
+            is Array<*> ->
+                if (other.any !is Array<*> || !this.any.contentDeepEquals(other.any))
+                    return false
+            is BooleanArray ->
+                if (other.any !is BooleanArray || !this.any.contentEquals(other.any))
+                    return false
+            is ByteArray ->
+                if (other.any !is ByteArray || !this.any.contentEquals(other.any))
+                    return false
+            is CharArray ->
+                if (other.any !is CharArray || !this.any.contentEquals(other.any))
+                    return false
+            is ShortArray ->
+                if (other.any !is ShortArray || !this.any.contentEquals(other.any))
+                    return false
+            is IntArray ->
+                if (other.any !is IntArray || !this.any.contentEquals(other.any))
+                    return false
+            is LongArray ->
+                if (other.any !is LongArray || !this.any.contentEquals(other.any))
+                    return false
+            is FloatArray ->
+                if (other.any !is FloatArray || !this.any.contentEquals(other.any))
+                    return false
+            is DoubleArray ->
+                if (other.any !is DoubleArray || !this.any.contentEquals(other.any))
+                    return false
+            else ->
+                if (this.any != other.any)
+                    return false
+        }
+
+        when (this.nullableAny) {
+            is Array<*> ->
+                if (other.nullableAny !is Array<*> || !this.nullableAny.contentDeepEquals(other.nullableAny))
+                    return false
+            is BooleanArray ->
+                if (other.nullableAny !is BooleanArray || !this.nullableAny.contentEquals(other.nullableAny))
+                    return false
+            is ByteArray ->
+                if (other.nullableAny !is ByteArray || !this.nullableAny.contentEquals(other.nullableAny))
+                    return false
+            is CharArray ->
+                if (other.nullableAny !is CharArray || !this.nullableAny.contentEquals(other.nullableAny))
+                    return false
+            is ShortArray ->
+                if (other.nullableAny !is ShortArray || !this.nullableAny.contentEquals(other.nullableAny))
+                    return false
+            is IntArray ->
+                if (other.nullableAny !is IntArray || !this.nullableAny.contentEquals(other.nullableAny))
+                    return false
+            is LongArray ->
+                if (other.nullableAny !is LongArray || !this.nullableAny.contentEquals(other.nullableAny))
+                    return false
+            is FloatArray ->
+                if (other.nullableAny !is FloatArray || !this.nullableAny.contentEquals(other.nullableAny))
+                    return false
+            is DoubleArray ->
+                if (other.nullableAny !is DoubleArray || !this.nullableAny.contentEquals(other.nullableAny))
+                    return false
+            else ->
+                if (this.nullableAny != other.nullableAny)
+                    return false
+        }
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = when (any) {
+            is Array<*> -> any.contentDeepHashCode()
+            is BooleanArray -> any.contentHashCode()
+            is ByteArray -> any.contentHashCode()
+            is CharArray -> any.contentHashCode()
+            is ShortArray -> any.contentHashCode()
+            is IntArray -> any.contentHashCode()
+            is LongArray -> any.contentHashCode()
+            is FloatArray -> any.contentHashCode()
+            is DoubleArray -> any.contentHashCode()
+            else -> any.hashCode()
+        }
+
+        result = result * 31 + when (nullableAny) {
+            is Array<*> -> nullableAny.contentDeepHashCode()
+            is BooleanArray -> nullableAny.contentHashCode()
+            is ByteArray -> nullableAny.contentHashCode()
+            is CharArray -> nullableAny.contentHashCode()
+            is ShortArray -> nullableAny.contentHashCode()
+            is IntArray -> nullableAny.contentHashCode()
+            is LongArray -> nullableAny.contentHashCode()
+            is FloatArray -> nullableAny.contentHashCode()
+            is DoubleArray -> nullableAny.contentHashCode()
+            else -> nullableAny.hashCode()
+        }
+
+        return result
+    }
+
+    override fun toString(): String {
+        return StringBuilder()
+            .append("AnyArrayHolder(")
+            .append("any=")
+            .append(
+                when (any) {
+                    is Array<*> -> any.contentDeepToString()
+                    is BooleanArray -> any.contentToString()
+                    is ByteArray -> any.contentToString()
+                    is CharArray -> any.contentToString()
+                    is ShortArray -> any.contentToString()
+                    is IntArray -> any.contentToString()
+                    is LongArray -> any.contentToString()
+                    is FloatArray -> any.contentToString()
+                    is DoubleArray -> any.contentToString()
+                    else -> any.toString()
+                }
+            )
+            .append(", ")
+            .append("nullableAny=")
+            .append(
+                when (nullableAny) {
+                    is Array<*> -> nullableAny.contentDeepToString()
+                    is BooleanArray -> nullableAny.contentToString()
+                    is ByteArray -> nullableAny.contentToString()
+                    is CharArray -> nullableAny.contentToString()
+                    is ShortArray -> nullableAny.contentToString()
+                    is IntArray -> nullableAny.contentToString()
+                    is LongArray -> nullableAny.contentToString()
+                    is FloatArray -> nullableAny.contentToString()
+                    is DoubleArray -> nullableAny.contentToString()
+                    else -> nullableAny.toString()
+                }
+            )
+            .append(")")
+            .toString()
+    }
+}

--- a/poko-compiler-plugin/src/test/resources/data/AnyArrayHolder.kt
+++ b/poko-compiler-plugin/src/test/resources/data/AnyArrayHolder.kt
@@ -8,6 +8,7 @@ package data
 data class AnyArrayHolder(
     val any: Any,
     val nullableAny: Any?,
+    val trailingProperty: String,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other)
@@ -20,6 +21,9 @@ data class AnyArrayHolder(
             return false
 
         if (!this.nullableAny.arrayContentDeepEquals(other.nullableAny))
+            return false
+
+        if (this.trailingProperty != other.trailingProperty)
             return false
 
         return true
@@ -45,6 +49,7 @@ data class AnyArrayHolder(
         var result = any.arrayContentDeepHashCode()
 
         result = result * 31 + nullableAny.arrayContentDeepHashCode()
+        result = result * 31 + trailingProperty.hashCode()
 
         return result
     }
@@ -73,6 +78,9 @@ data class AnyArrayHolder(
             .append(", ")
             .append("nullableAny=")
             .append(nullableAny.arrayContentDeepToString())
+            .append(", ")
+            .append("trailingProperty=")
+            .append(trailingProperty)
             .append(")")
             .toString()
     }

--- a/poko-compiler-plugin/src/test/resources/data/AnyArrayHolder.kt
+++ b/poko-compiler-plugin/src/test/resources/data/AnyArrayHolder.kt
@@ -16,140 +16,80 @@ data class AnyArrayHolder(
         if (other !is AnyArrayHolder)
             return false
 
-        when (this.any) {
-            is Array<*> ->
-                if (other.any !is Array<*> || !this.any.contentDeepEquals(other.any))
-                    return false
-            is BooleanArray ->
-                if (other.any !is BooleanArray || !this.any.contentEquals(other.any))
-                    return false
-            is ByteArray ->
-                if (other.any !is ByteArray || !this.any.contentEquals(other.any))
-                    return false
-            is CharArray ->
-                if (other.any !is CharArray || !this.any.contentEquals(other.any))
-                    return false
-            is ShortArray ->
-                if (other.any !is ShortArray || !this.any.contentEquals(other.any))
-                    return false
-            is IntArray ->
-                if (other.any !is IntArray || !this.any.contentEquals(other.any))
-                    return false
-            is LongArray ->
-                if (other.any !is LongArray || !this.any.contentEquals(other.any))
-                    return false
-            is FloatArray ->
-                if (other.any !is FloatArray || !this.any.contentEquals(other.any))
-                    return false
-            is DoubleArray ->
-                if (other.any !is DoubleArray || !this.any.contentEquals(other.any))
-                    return false
-            else ->
-                if (this.any != other.any)
-                    return false
-        }
+        if (!this.any.arrayContentDeepEquals(other.any))
+            return false
 
-        when (this.nullableAny) {
-            is Array<*> ->
-                if (other.nullableAny !is Array<*> || !this.nullableAny.contentDeepEquals(other.nullableAny))
-                    return false
-            is BooleanArray ->
-                if (other.nullableAny !is BooleanArray || !this.nullableAny.contentEquals(other.nullableAny))
-                    return false
-            is ByteArray ->
-                if (other.nullableAny !is ByteArray || !this.nullableAny.contentEquals(other.nullableAny))
-                    return false
-            is CharArray ->
-                if (other.nullableAny !is CharArray || !this.nullableAny.contentEquals(other.nullableAny))
-                    return false
-            is ShortArray ->
-                if (other.nullableAny !is ShortArray || !this.nullableAny.contentEquals(other.nullableAny))
-                    return false
-            is IntArray ->
-                if (other.nullableAny !is IntArray || !this.nullableAny.contentEquals(other.nullableAny))
-                    return false
-            is LongArray ->
-                if (other.nullableAny !is LongArray || !this.nullableAny.contentEquals(other.nullableAny))
-                    return false
-            is FloatArray ->
-                if (other.nullableAny !is FloatArray || !this.nullableAny.contentEquals(other.nullableAny))
-                    return false
-            is DoubleArray ->
-                if (other.nullableAny !is DoubleArray || !this.nullableAny.contentEquals(other.nullableAny))
-                    return false
-            else ->
-                if (this.nullableAny != other.nullableAny)
-                    return false
-        }
+        if (!this.nullableAny.arrayContentDeepEquals(other.nullableAny))
+            return false
 
         return true
     }
 
-    override fun hashCode(): Int {
-        var result = when (any) {
-            is Array<*> -> any.contentDeepHashCode()
-            is BooleanArray -> any.contentHashCode()
-            is ByteArray -> any.contentHashCode()
-            is CharArray -> any.contentHashCode()
-            is ShortArray -> any.contentHashCode()
-            is IntArray -> any.contentHashCode()
-            is LongArray -> any.contentHashCode()
-            is FloatArray -> any.contentHashCode()
-            is DoubleArray -> any.contentHashCode()
-            else -> any.hashCode()
+    @Suppress("NOTHING_TO_INLINE")
+    private inline fun Any?.arrayContentDeepEquals(other: Any?): Boolean {
+        return when (this) {
+            is Array<*> -> other is Array<*> && this.contentDeepEquals(other)
+            is BooleanArray -> other is BooleanArray && this.contentEquals(other)
+            is ByteArray -> other is ByteArray && this.contentEquals(other)
+            is CharArray -> other is CharArray && this.contentEquals(other)
+            is ShortArray -> other is ShortArray && this.contentEquals(other)
+            is IntArray -> other is IntArray && this.contentEquals(other)
+            is LongArray -> other is LongArray && this.contentEquals(other)
+            is FloatArray -> other is FloatArray && this.contentEquals(other)
+            is DoubleArray -> other is DoubleArray && this.contentEquals(other)
+            else -> this == other
         }
+    }
 
-        result = result * 31 + when (nullableAny) {
-            is Array<*> -> nullableAny.contentDeepHashCode()
-            is BooleanArray -> nullableAny.contentHashCode()
-            is ByteArray -> nullableAny.contentHashCode()
-            is CharArray -> nullableAny.contentHashCode()
-            is ShortArray -> nullableAny.contentHashCode()
-            is IntArray -> nullableAny.contentHashCode()
-            is LongArray -> nullableAny.contentHashCode()
-            is FloatArray -> nullableAny.contentHashCode()
-            is DoubleArray -> nullableAny.contentHashCode()
-            else -> nullableAny.hashCode()
-        }
+    override fun hashCode(): Int {
+        var result = any.arrayContentDeepHashCode()
+
+        result = result * 31 + nullableAny.arrayContentDeepHashCode()
 
         return result
+    }
+
+    @Suppress("NOTHING_TO_INLINE")
+    private inline fun Any?.arrayContentDeepHashCode(): Int {
+        return when (this) {
+            is Array<*> -> this.contentDeepHashCode()
+            is BooleanArray -> this.contentHashCode()
+            is ByteArray -> this.contentHashCode()
+            is CharArray -> this.contentHashCode()
+            is ShortArray -> this.contentHashCode()
+            is IntArray -> this.contentHashCode()
+            is LongArray -> this.contentHashCode()
+            is FloatArray -> this.contentHashCode()
+            is DoubleArray -> this.contentHashCode()
+            else -> this.hashCode()
+        }
     }
 
     override fun toString(): String {
         return StringBuilder()
             .append("AnyArrayHolder(")
             .append("any=")
-            .append(
-                when (any) {
-                    is Array<*> -> any.contentDeepToString()
-                    is BooleanArray -> any.contentToString()
-                    is ByteArray -> any.contentToString()
-                    is CharArray -> any.contentToString()
-                    is ShortArray -> any.contentToString()
-                    is IntArray -> any.contentToString()
-                    is LongArray -> any.contentToString()
-                    is FloatArray -> any.contentToString()
-                    is DoubleArray -> any.contentToString()
-                    else -> any.toString()
-                }
-            )
+            .append(any.arrayContentDeepToString())
             .append(", ")
             .append("nullableAny=")
-            .append(
-                when (nullableAny) {
-                    is Array<*> -> nullableAny.contentDeepToString()
-                    is BooleanArray -> nullableAny.contentToString()
-                    is ByteArray -> nullableAny.contentToString()
-                    is CharArray -> nullableAny.contentToString()
-                    is ShortArray -> nullableAny.contentToString()
-                    is IntArray -> nullableAny.contentToString()
-                    is LongArray -> nullableAny.contentToString()
-                    is FloatArray -> nullableAny.contentToString()
-                    is DoubleArray -> nullableAny.contentToString()
-                    else -> nullableAny.toString()
-                }
-            )
+            .append(nullableAny.arrayContentDeepToString())
             .append(")")
             .toString()
+    }
+
+    @Suppress("NOTHING_TO_INLINE")
+    private inline fun Any?.arrayContentDeepToString(): String {
+        return when (this) {
+            is Array<*> -> this.contentDeepToString()
+            is BooleanArray -> this.contentToString()
+            is ByteArray -> this.contentToString()
+            is CharArray -> this.contentToString()
+            is ShortArray -> this.contentToString()
+            is IntArray -> this.contentToString()
+            is LongArray -> this.contentToString()
+            is FloatArray -> this.contentToString()
+            is DoubleArray -> this.contentToString()
+            else -> this.toString()
+        }
     }
 }

--- a/sample/jvm/src/main/kotlin/dev/drewhamilton/poko/sample/jvm/arrays/HandwrittenArrayHolder.kt
+++ b/sample/jvm/src/main/kotlin/dev/drewhamilton/poko/sample/jvm/arrays/HandwrittenArrayHolder.kt
@@ -23,39 +23,8 @@ class HandwrittenArrayHolder(
         if (this.array != other.array)
             return false
 
-        // TODO: Revert?
-        when (this.maybe) {
-            is Array<*> ->
-                if (other.maybe !is Array<*> || !this.maybe.contentDeepEquals(other.maybe))
-                    return false
-            is BooleanArray ->
-                if (other.maybe !is BooleanArray || !this.maybe.contentEquals(other.maybe))
-                    return false
-            is ByteArray ->
-                if (other.maybe !is ByteArray || !this.maybe.contentEquals(other.maybe))
-                    return false
-            is CharArray ->
-                if (other.maybe !is CharArray || !this.maybe.contentEquals(other.maybe))
-                    return false
-            is ShortArray ->
-                if (other.maybe !is ShortArray || !this.maybe.contentEquals(other.maybe))
-                    return false
-            is IntArray ->
-                if (other.maybe !is IntArray || !this.maybe.contentEquals(other.maybe))
-                    return false
-            is LongArray ->
-                if (other.maybe !is LongArray || !this.maybe.contentEquals(other.maybe))
-                    return false
-            is FloatArray ->
-                if (other.maybe !is FloatArray || !this.maybe.contentEquals(other.maybe))
-                    return false
-            is DoubleArray ->
-                if (other.maybe !is DoubleArray || !this.maybe.contentEquals(other.maybe))
-                    return false
-            else ->
-                if (this.maybe != other.maybe)
-                    return false
-        }
+        if (this.maybe != other.maybe)
+            return false
 
         return true
     }
@@ -65,18 +34,7 @@ class HandwrittenArrayHolder(
 
         result = result * 31 + array.contentHashCode()
 
-        result = result * 31 + when (maybe) {
-            is Array<*> -> maybe.contentDeepHashCode()
-            is BooleanArray -> maybe.contentHashCode()
-            is ByteArray -> maybe.contentHashCode()
-            is CharArray -> maybe.contentHashCode()
-            is ShortArray -> maybe.contentHashCode()
-            is IntArray -> maybe.contentHashCode()
-            is LongArray -> maybe.contentHashCode()
-            is FloatArray -> maybe.contentHashCode()
-            is DoubleArray -> maybe.contentHashCode()
-            else -> maybe.hashCode()
-        }
+        result = result * 31 + maybe.hashCode()
 
         return result
     }
@@ -91,20 +49,7 @@ class HandwrittenArrayHolder(
             .append(array.contentToString())
             .append(", ")
             .append("maybe=")
-            .append(
-                when (maybe) {
-                    is Array<*> -> maybe.contentDeepToString()
-                    is BooleanArray -> maybe.contentToString()
-                    is ByteArray -> maybe.contentToString()
-                    is CharArray -> maybe.contentToString()
-                    is ShortArray -> maybe.contentToString()
-                    is IntArray -> maybe.contentToString()
-                    is LongArray -> maybe.contentToString()
-                    is FloatArray -> maybe.contentToString()
-                    is DoubleArray -> maybe.contentToString()
-                    else -> maybe.toString()
-                }
-            )
+            .append(maybe)
             .append(")")
             .toString()
     }

--- a/sample/jvm/src/main/kotlin/dev/drewhamilton/poko/sample/jvm/arrays/HandwrittenArrayHolder.kt
+++ b/sample/jvm/src/main/kotlin/dev/drewhamilton/poko/sample/jvm/arrays/HandwrittenArrayHolder.kt
@@ -23,8 +23,39 @@ class HandwrittenArrayHolder(
         if (this.array != other.array)
             return false
 
-        if (this.maybe != other.maybe)
-            return false
+        // TODO: Revert?
+        when (this.maybe) {
+            is Array<*> ->
+                if (other.maybe !is Array<*> || !this.maybe.contentDeepEquals(other.maybe))
+                    return false
+            is BooleanArray ->
+                if (other.maybe !is BooleanArray || !this.maybe.contentEquals(other.maybe))
+                    return false
+            is ByteArray ->
+                if (other.maybe !is ByteArray || !this.maybe.contentEquals(other.maybe))
+                    return false
+            is CharArray ->
+                if (other.maybe !is CharArray || !this.maybe.contentEquals(other.maybe))
+                    return false
+            is ShortArray ->
+                if (other.maybe !is ShortArray || !this.maybe.contentEquals(other.maybe))
+                    return false
+            is IntArray ->
+                if (other.maybe !is IntArray || !this.maybe.contentEquals(other.maybe))
+                    return false
+            is LongArray ->
+                if (other.maybe !is LongArray || !this.maybe.contentEquals(other.maybe))
+                    return false
+            is FloatArray ->
+                if (other.maybe !is FloatArray || !this.maybe.contentEquals(other.maybe))
+                    return false
+            is DoubleArray ->
+                if (other.maybe !is DoubleArray || !this.maybe.contentEquals(other.maybe))
+                    return false
+            else ->
+                if (this.maybe != other.maybe)
+                    return false
+        }
 
         return true
     }
@@ -34,7 +65,18 @@ class HandwrittenArrayHolder(
 
         result = result * 31 + array.contentHashCode()
 
-        result = result * 31 + maybe.hashCode()
+        result = result * 31 + when (maybe) {
+            is Array<*> -> maybe.contentDeepHashCode()
+            is BooleanArray -> maybe.contentHashCode()
+            is ByteArray -> maybe.contentHashCode()
+            is CharArray -> maybe.contentHashCode()
+            is ShortArray -> maybe.contentHashCode()
+            is IntArray -> maybe.contentHashCode()
+            is LongArray -> maybe.contentHashCode()
+            is FloatArray -> maybe.contentHashCode()
+            is DoubleArray -> maybe.contentHashCode()
+            else -> maybe.hashCode()
+        }
 
         return result
     }
@@ -49,7 +91,20 @@ class HandwrittenArrayHolder(
             .append(array.contentToString())
             .append(", ")
             .append("maybe=")
-            .append(maybe)
+            .append(
+                when (maybe) {
+                    is Array<*> -> maybe.contentDeepToString()
+                    is BooleanArray -> maybe.contentToString()
+                    is ByteArray -> maybe.contentToString()
+                    is CharArray -> maybe.contentToString()
+                    is ShortArray -> maybe.contentToString()
+                    is IntArray -> maybe.contentToString()
+                    is LongArray -> maybe.contentToString()
+                    is FloatArray -> maybe.contentToString()
+                    is DoubleArray -> maybe.contentToString()
+                    else -> maybe.toString()
+                }
+            )
             .append(")")
             .toString()
     }


### PR DESCRIPTION
#1 part 4a: Implements support for properties of type `Any?` that turn out to be typed `Array`s at runtime.

Does not implement the same support for properties of type `Any?` that turn out to be primitive arrays at runtime: This is making `PokoMembersTransformer` very large and disorganized, so I want to clean up before I continue.

Does not implement the same support for generic properties: That check is a touch more complicated so I'll add that afterward.