### PR TITLE
Extract shared generation helpers from PokoMembersTransformer

### DIFF
--- a/poko-compiler-plugin/build.gradle.kts
+++ b/poko-compiler-plugin/build.gradle.kts
@@ -3,6 +3,7 @@ import dev.drewhamilton.poko.build.generateArtifactInfo
 import dev.drewhamilton.poko.build.setUpPublication
 import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
@@ -37,6 +38,12 @@ dependencies {
 
 kotlin {
     explicitApi = ExplicitApiMode.Strict
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    compilerOptions {
+        freeCompilerArgs.add("-Xcontext-receivers")
+    }
 }
 
 // https://jakewharton.com/build-on-latest-java-test-through-lowest-java/

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/functionGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/functionGeneration.kt
@@ -1,19 +1,13 @@
 package dev.drewhamilton.poko.ir
 
-import org.jetbrains.kotlin.descriptors.impl.LazyClassReceiverParameterDescriptor
-import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
 import org.jetbrains.kotlin.ir.builders.IrBlockBodyBuilder
 import org.jetbrains.kotlin.ir.builders.IrGeneratorContext
-import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrProperty
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
-import org.jetbrains.kotlin.ir.declarations.impl.IrValueParameterImpl
 import org.jetbrains.kotlin.ir.expressions.IrGetValue
 import org.jetbrains.kotlin.ir.expressions.impl.IrGetValueImpl
 import org.jetbrains.kotlin.ir.symbols.IrClassifierSymbol
-import org.jetbrains.kotlin.ir.symbols.impl.IrValueParameterSymbolImpl
-import org.jetbrains.kotlin.ir.types.createType
 import org.jetbrains.kotlin.ir.util.render
 
 /**
@@ -25,49 +19,19 @@ internal val IrProperty.type
         ?: error("Can't find type of ${render()}")
 
 /**
- * Converts the function's dispatch receiver parameter (i.e. <this>) to the function's parent.
- * This is necessary because we are taking the base declaration from a parent class (or Any) and
- * pseudo-overriding it in this function's parent class.
- */
-internal fun IrFunction.mutateWithNewDispatchReceiverParameterForParentClass() {
-    val parentClass = parent as IrClass
-    val originalReceiver = requireNotNull(dispatchReceiverParameter)
-    dispatchReceiverParameter = IrValueParameterImpl(
-        startOffset = originalReceiver.startOffset,
-        endOffset = originalReceiver.endOffset,
-        origin = originalReceiver.origin,
-        symbol = IrValueParameterSymbolImpl(
-            // IrValueParameterSymbolImpl requires a descriptor; same type as
-            // originalReceiver.symbol:
-            @OptIn(ObsoleteDescriptorBasedAPI::class)
-            LazyClassReceiverParameterDescriptor(parentClass.descriptor)
-        ),
-        name = originalReceiver.name,
-        index = originalReceiver.index,
-        type = parentClass.symbol.createType(hasQuestionMark = false, emptyList()),
-        varargElementType = originalReceiver.varargElementType,
-        isCrossinline = originalReceiver.isCrossinline,
-        isNoinline = originalReceiver.isNoinline,
-        isHidden = originalReceiver.isHidden,
-        isAssignable = originalReceiver.isAssignable
-    ).apply {
-        parent = this@mutateWithNewDispatchReceiverParameterForParentClass
-    }
-}
-
-/**
- * The receiver value (i.e. `this`) for a [function] with a dispatch (i.e. non-extension) receiver.
+ * The receiver value (i.e. `this`) for a function with a dispatch (i.e. non-extension) receiver.
  *
- * In the context of Poko, only works properly after
- * [mutateWithNewDispatchReceiverParameterForParentClass] has been called on [function].
+ * In the context of Poko, only works properly after the overridden method has had its
+ * `dispatchReceiverParameter` updated to the current parent class.
  */
-internal fun IrBlockBodyBuilder.receiver(function: IrFunction): IrGetValue =
-    IrGetValueImpl(function.dispatchReceiverParameter!!)
+context(IrBlockBodyBuilder)
+internal fun IrFunction.receiverValue(): IrGetValue = IrGetValueImpl(dispatchReceiverParameter!!)
 
 /**
  * Gets the value of the given [parameter].
  */
-internal fun IrBlockBodyBuilder.IrGetValueImpl(
+context(IrBlockBodyBuilder)
+internal fun IrGetValueImpl(
     parameter: IrValueParameter,
 ) = IrGetValueImpl(
     startOffset = startOffset,
@@ -75,16 +39,6 @@ internal fun IrBlockBodyBuilder.IrGetValueImpl(
     type = parameter.type,
     symbol = parameter.symbol,
 )
-
-/**
- * Uses reflection to set an [IrFunction]'s private `isFakeOverride` property.
- */
-internal fun IrFunction.reflectivelySetFakeOverride(isFakeOverride: Boolean) {
-    with(javaClass.getDeclaredField("isFakeOverride")) {
-        isAccessible = true
-        setBoolean(this@reflectivelySetFakeOverride, isFakeOverride)
-    }
-}
 
 /**
  * Returns true if the classifier represents a typed or primitive array.

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/functionGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/functionGeneration.kt
@@ -1,0 +1,97 @@
+package dev.drewhamilton.poko.ir
+
+import org.jetbrains.kotlin.descriptors.impl.LazyClassReceiverParameterDescriptor
+import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
+import org.jetbrains.kotlin.ir.builders.IrBlockBodyBuilder
+import org.jetbrains.kotlin.ir.builders.IrGeneratorContext
+import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.declarations.IrProperty
+import org.jetbrains.kotlin.ir.declarations.IrValueParameter
+import org.jetbrains.kotlin.ir.declarations.impl.IrValueParameterImpl
+import org.jetbrains.kotlin.ir.expressions.IrGetValue
+import org.jetbrains.kotlin.ir.expressions.impl.IrGetValueImpl
+import org.jetbrains.kotlin.ir.symbols.IrClassifierSymbol
+import org.jetbrains.kotlin.ir.symbols.impl.IrValueParameterSymbolImpl
+import org.jetbrains.kotlin.ir.types.createType
+import org.jetbrains.kotlin.ir.util.render
+
+/**
+ * The type of an [IrProperty].
+ */
+internal val IrProperty.type
+    get() = backingField?.type
+        ?: getter?.returnType
+        ?: error("Can't find type of ${render()}")
+
+/**
+ * Converts the function's dispatch receiver parameter (i.e. <this>) to the function's parent.
+ * This is necessary because we are taking the base declaration from a parent class (or Any) and
+ * pseudo-overriding it in this function's parent class.
+ */
+internal fun IrFunction.mutateWithNewDispatchReceiverParameterForParentClass() {
+    val parentClass = parent as IrClass
+    val originalReceiver = requireNotNull(dispatchReceiverParameter)
+    dispatchReceiverParameter = IrValueParameterImpl(
+        startOffset = originalReceiver.startOffset,
+        endOffset = originalReceiver.endOffset,
+        origin = originalReceiver.origin,
+        symbol = IrValueParameterSymbolImpl(
+            // IrValueParameterSymbolImpl requires a descriptor; same type as
+            // originalReceiver.symbol:
+            @OptIn(ObsoleteDescriptorBasedAPI::class)
+            LazyClassReceiverParameterDescriptor(parentClass.descriptor)
+        ),
+        name = originalReceiver.name,
+        index = originalReceiver.index,
+        type = parentClass.symbol.createType(hasQuestionMark = false, emptyList()),
+        varargElementType = originalReceiver.varargElementType,
+        isCrossinline = originalReceiver.isCrossinline,
+        isNoinline = originalReceiver.isNoinline,
+        isHidden = originalReceiver.isHidden,
+        isAssignable = originalReceiver.isAssignable
+    ).apply {
+        parent = this@mutateWithNewDispatchReceiverParameterForParentClass
+    }
+}
+
+/**
+ * The receiver value (i.e. `this`) for a [function] with a dispatch (i.e. non-extension) receiver.
+ *
+ * In the context of Poko, only works properly after
+ * [mutateWithNewDispatchReceiverParameterForParentClass] has been called on [function].
+ */
+internal fun IrBlockBodyBuilder.receiver(function: IrFunction): IrGetValue =
+    IrGetValueImpl(function.dispatchReceiverParameter!!)
+
+/**
+ * Gets the value of the given [parameter].
+ */
+internal fun IrBlockBodyBuilder.IrGetValueImpl(
+    parameter: IrValueParameter,
+) = IrGetValueImpl(
+    startOffset = startOffset,
+    endOffset = endOffset,
+    type = parameter.type,
+    symbol = parameter.symbol,
+)
+
+/**
+ * Uses reflection to set an [IrFunction]'s private `isFakeOverride` property.
+ */
+internal fun IrFunction.reflectivelySetFakeOverride(isFakeOverride: Boolean) {
+    with(javaClass.getDeclaredField("isFakeOverride")) {
+        isAccessible = true
+        setBoolean(this@reflectivelySetFakeOverride, isFakeOverride)
+    }
+}
+
+/**
+ * Returns true if the classifier represents a typed or primitive array.
+ */
+internal fun IrClassifierSymbol?.isArrayOrPrimitiveArray(
+    context: IrGeneratorContext,
+): Boolean {
+    return this == context.irBuiltIns.arrayClass ||
+        this in context.irBuiltIns.primitiveArraysToPrimitiveTypes
+}

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/logging.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/logging.kt
@@ -1,0 +1,27 @@
+package dev.drewhamilton.poko.ir
+
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.cli.common.messages.MessageUtil
+import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
+import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.declarations.IrProperty
+import org.jetbrains.kotlin.resolve.source.getPsi
+
+internal fun MessageCollector.log(message: String) {
+    report(CompilerMessageSeverity.LOGGING, "POKO COMPILER PLUGIN (IR): $message")
+}
+
+internal fun MessageCollector.reportErrorOnClass(irClass: IrClass, message: String) {
+    val psi = irClass.source.getPsi()
+    val location = MessageUtil.psiElementToMessageLocation(psi)
+    report(CompilerMessageSeverity.ERROR, message, location)
+}
+
+// TODO: Implement an FIR-based declaration checker:
+@OptIn(ObsoleteDescriptorBasedAPI::class)
+internal fun MessageCollector.reportErrorOnProperty(property: IrProperty, message: String) {
+    val psi = property.descriptor.source.getPsi()
+    val location = MessageUtil.psiElementToMessageLocation(psi)
+    report(CompilerMessageSeverity.ERROR, message, location)
+}


### PR DESCRIPTION
Start to improve the readability of the generation code by extracting the shared helpers that will be used by each of the to-be-extracted `equals`, `hashCode`, and `toString` generation helpers.