### PR TITLE
Runtime boolean array support

### DIFF
--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/equalsGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/equalsGeneration.kt
@@ -152,7 +152,7 @@ private fun IrBuilderWithScope.irRuntimeArrayContentDeepEquals(
             irArrayTypeCheckAndContentDeepEqualsBranch(
                 receiver = receiver,
                 argument = argument,
-                classSymbol = PrimitiveType.BOOLEAN.toPrimitiveArrayClassSymbol(),
+                classSymbol = with(context) { PrimitiveType.BOOLEAN.toPrimitiveArrayClassSymbol() },
             ),
 
             // TODO: Primitive arrays

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/equalsGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/equalsGeneration.kt
@@ -164,6 +164,10 @@ private fun IrBuilderWithScope.irRuntimeArrayContentDeepEquals(
     )
 }
 
+/**
+ * Generates a runtime `when` branch checking for content deep equality of [receiver] and
+ * [argument]. The branch is only executed if [receiver] is an instance of [classSymbol].
+ */
 context(IrPluginContext)
 private fun IrBuilderWithScope.irArrayTypeCheckAndContentDeepEqualsBranch(
     receiver: IrExpression,

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/functionGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/functionGeneration.kt
@@ -2,7 +2,6 @@ package dev.drewhamilton.poko.ir
 
 import org.jetbrains.kotlin.builtins.PrimitiveType
 import org.jetbrains.kotlin.ir.builders.IrBlockBodyBuilder
-import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
 import org.jetbrains.kotlin.ir.builders.IrGeneratorContext
 import org.jetbrains.kotlin.ir.builders.IrGeneratorContextInterface
 import org.jetbrains.kotlin.ir.declarations.IrFunction
@@ -78,14 +77,6 @@ internal fun IrClassifierSymbol?.mayBeRuntimeArray(
     context: IrGeneratorContext,
 ): Boolean {
     return this == context.irBuiltIns.anyClass
-}
-
-@Deprecated("Use createArrayType")
-internal fun IrBuilderWithScope.starArrayType(): IrSimpleType {
-    return context.irBuiltIns.arrayClass.createType(
-        hasQuestionMark = false,
-        arguments = listOf(IrStarProjectionImpl),
-    )
 }
 
 context(IrGeneratorContextInterface)

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/functionGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/functionGeneration.kt
@@ -1,13 +1,16 @@
 package dev.drewhamilton.poko.ir
 
+import org.jetbrains.kotlin.builtins.PrimitiveType
 import org.jetbrains.kotlin.ir.builders.IrBlockBodyBuilder
 import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
 import org.jetbrains.kotlin.ir.builders.IrGeneratorContext
+import org.jetbrains.kotlin.ir.builders.IrGeneratorContextInterface
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrProperty
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.expressions.IrGetValue
 import org.jetbrains.kotlin.ir.expressions.impl.IrGetValueImpl
+import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrClassifierSymbol
 import org.jetbrains.kotlin.ir.types.IrSimpleType
 import org.jetbrains.kotlin.ir.types.createType
@@ -77,9 +80,25 @@ internal fun IrClassifierSymbol?.mayBeRuntimeArray(
     return this == context.irBuiltIns.anyClass
 }
 
-internal fun IrBuilderWithScope.starArrayType(): IrSimpleType{
+@Deprecated("Use createArrayType")
+internal fun IrBuilderWithScope.starArrayType(): IrSimpleType {
     return context.irBuiltIns.arrayClass.createType(
         hasQuestionMark = false,
         arguments = listOf(IrStarProjectionImpl),
     )
+}
+
+context(IrGeneratorContextInterface)
+internal fun PrimitiveType.toPrimitiveArrayClassSymbol(): IrClassSymbol {
+    return irBuiltIns.primitiveTypesToPrimitiveArrays.getValue(this)
+}
+
+context(IrGeneratorContextInterface)
+internal fun IrClassSymbol.createArrayType(): IrSimpleType {
+    val typeArguments = when {
+        this == irBuiltIns.arrayClass -> listOf(IrStarProjectionImpl)
+        this in irBuiltIns.primitiveArraysToPrimitiveTypes -> emptyList()
+        else -> throw IllegalArgumentException("$this is not an array class symbol")
+    }
+    return createType(hasQuestionMark = false, arguments = typeArguments)
 }

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
@@ -216,7 +216,7 @@ private fun IrBlockBodyBuilder.irArrayTypeCheckAndContentDeepHashCodeBranch(
     return irBranch(
         condition = irIs(value, type),
         result = irCall(
-            callee = findArrayDeepContentHashCodeFunction(classSymbol),
+            callee = findArrayContentDeepHashCodeFunction(classSymbol),
             type = context.irBuiltIns.intType,
         ).apply {
             extensionReceiver = value
@@ -248,11 +248,11 @@ private fun IrBlockBodyBuilder.maybeFindArrayDeepHashCodeFunction(
         return null
     }
 
-    return findArrayDeepContentHashCodeFunction(propertyClassifier)
+    return findArrayContentDeepHashCodeFunction(propertyClassifier)
 }
 
 context(IrPluginContext)
-private fun IrBlockBodyBuilder.findArrayDeepContentHashCodeFunction(
+private fun IrBlockBodyBuilder.findArrayContentDeepHashCodeFunction(
     propertyClassifier: IrClassifierSymbol,
 ): IrSimpleFunctionSymbol {
     val callableName = if (propertyClassifier == context.irBuiltIns.arrayClass) {

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
@@ -1,6 +1,7 @@
 package dev.drewhamilton.poko.ir
 
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.builtins.PrimitiveType
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.ir.builders.IrBlockBodyBuilder
 import org.jetbrains.kotlin.ir.builders.IrGeneratorContextInterface
@@ -22,6 +23,7 @@ import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrProperty
 import org.jetbrains.kotlin.ir.declarations.IrTypeParameter
 import org.jetbrains.kotlin.ir.declarations.impl.IrVariableImpl
+import org.jetbrains.kotlin.ir.expressions.IrBranch
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrClassifierSymbol
@@ -169,21 +171,17 @@ context(IrPluginContext)
 private fun IrBlockBodyBuilder.irRuntimeArrayContentDeepHashCode(
     value: IrExpression,
 ): IrExpression {
-    val starArrayType = starArrayType()
     return irWhen(
         type = context.irBuiltIns.intType,
         branches = listOf(
-            irBranch(
-                condition = irIs(
-                    argument = value,
-                    type = starArrayType,
-                ),
-                result = irCall(
-                    callee = findArrayDeepHashCodeFunction(context.irBuiltIns.arrayClass),
-                    type = context.irBuiltIns.intType,
-                ).apply {
-                    extensionReceiver = value
-                }
+            irArrayTypeCheckAndContentDeepHashCodeBranch(
+                value = value,
+                classSymbol = context.irBuiltIns.arrayClass,
+            ),
+
+            irArrayTypeCheckAndContentDeepHashCodeBranch(
+                value = value,
+                classSymbol = PrimitiveType.BOOLEAN.toPrimitiveArrayClassSymbol(),
             ),
 
             // TODO: Primitive arrays
@@ -202,6 +200,27 @@ private fun IrBlockBodyBuilder.irRuntimeArrayContentDeepHashCode(
                 ),
             ),
         ),
+    )
+}
+
+/**
+ * Generates a runtime `when` branch computing the content deep hashCode of [value]. The branch is
+ * only executed if [value] is an instance of [classSymbol].
+ */
+context(IrPluginContext)
+private fun IrBlockBodyBuilder.irArrayTypeCheckAndContentDeepHashCodeBranch(
+    value: IrExpression,
+    classSymbol: IrClassSymbol,
+): IrBranch {
+    val type = with(context) { classSymbol.createArrayType() }
+    return irBranch(
+        condition = irIs(value, type),
+        result = irCall(
+            callee = findArrayDeepContentHashCodeFunction(classSymbol),
+            type = context.irBuiltIns.intType,
+        ).apply {
+            extensionReceiver = value
+        }
     )
 }
 
@@ -229,11 +248,11 @@ private fun IrBlockBodyBuilder.maybeFindArrayDeepHashCodeFunction(
         return null
     }
 
-    return findArrayDeepHashCodeFunction(propertyClassifier)
+    return findArrayDeepContentHashCodeFunction(propertyClassifier)
 }
 
 context(IrPluginContext)
-private fun IrBlockBodyBuilder.findArrayDeepHashCodeFunction(
+private fun IrBlockBodyBuilder.findArrayDeepContentHashCodeFunction(
     propertyClassifier: IrClassifierSymbol,
 ): IrSimpleFunctionSymbol {
     val callableName = if (propertyClassifier == context.irBuiltIns.arrayClass) {

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
@@ -181,7 +181,7 @@ private fun IrBlockBodyBuilder.irRuntimeArrayContentDeepHashCode(
 
             irArrayTypeCheckAndContentDeepHashCodeBranch(
                 value = value,
-                classSymbol = PrimitiveType.BOOLEAN.toPrimitiveArrayClassSymbol(),
+                classSymbol = with(context) { PrimitiveType.BOOLEAN.toPrimitiveArrayClassSymbol() },
             ),
 
             // TODO: Primitive arrays

--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
@@ -693,6 +693,34 @@ class PokoCompilerPluginTest {
         }
     }
 
+    @Test fun `two AnyArrayHolder instances holding equivalent boolean arrays are equals`() {
+        compareAnyArrayHolderApiInstances(
+            any1 = booleanArrayOf(false, true, true),
+            any2 = booleanArrayOf(false, true, true),
+        ) { firstInstance, secondInstance ->
+            assertThat(firstInstance).isEqualTo(secondInstance)
+            assertThat(secondInstance).isEqualTo(firstInstance)
+        }
+    }
+
+    @Test fun `two AnyArrayHolder instances holding equivalent boolean arrays have same hashCode`() {
+        compareAnyArrayHolderApiInstances(
+            any1 = booleanArrayOf(false, true, false),
+            any2 = booleanArrayOf(false, true, false),
+        ) { firstInstance, secondInstance ->
+            assertThat(firstInstance.hashCode()).isEqualTo(secondInstance.hashCode())
+        }
+    }
+
+    @Test fun `two AnyArrayHolder instances holding equivalent boolean arrays have same toString`() {
+        compareAnyArrayHolderApiInstances(
+            any1 = booleanArrayOf(false, false, true),
+            any2 = booleanArrayOf(false, false, true),
+        ) { firstInstance, secondInstance ->
+            assertThat(firstInstance.toString()).isEqualTo(secondInstance.toString())
+        }
+    }
+
     @Test fun `two AnyArrayHolder instances holding equivalent non-arrays are equals`() {
         compareAnyArrayHolderApiInstances(
             any1 = listOf("one", "two"),


### PR DESCRIPTION
#1 part 4b: Implements support for properties of type `Any?` that turn out to be `BooleanArray`s at runtime.

Refactors the existing typed array helpers to be easy to reuse. All other primitive types can now be an easy fast-follow to this.

Does not implement the same support for generic properties: I'll add that separately.