### PR TITLE
Runtime array support for generic properties

### DIFF
--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/equalsGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/equalsGeneration.kt
@@ -112,8 +112,10 @@ private fun IrBuilderWithScope.irArrayContentDeepEquals(
     val propertyType = property.type
     val propertyClassifier = propertyType.classifierOrFail
 
-    if (!propertyClassifier.isArrayOrPrimitiveArray(context)) {
-        return if (propertyClassifier.mayBeRuntimeArray(context)) {
+    val isArray = with(context) { propertyClassifier.isArrayOrPrimitiveArray() }
+    if (!isArray) {
+        val mayBeRuntimeArray = with(context) { propertyClassifier.mayBeRuntimeArray() }
+        return if (mayBeRuntimeArray) {
             irRuntimeArrayContentDeepEquals(receiver, argument)
         } else {
             messageCollector.reportErrorOnProperty(

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
@@ -21,7 +21,6 @@ import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrProperty
-import org.jetbrains.kotlin.ir.declarations.IrTypeParameter
 import org.jetbrains.kotlin.ir.declarations.impl.IrVariableImpl
 import org.jetbrains.kotlin.ir.expressions.IrBranch
 import org.jetbrains.kotlin.ir.expressions.IrExpression
@@ -30,13 +29,10 @@ import org.jetbrains.kotlin.ir.symbols.IrClassifierSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.IrTypeParameterSymbol
 import org.jetbrains.kotlin.ir.symbols.impl.IrVariableSymbolImpl
-import org.jetbrains.kotlin.ir.types.classOrNull
 import org.jetbrains.kotlin.ir.types.classifierOrFail
 import org.jetbrains.kotlin.ir.types.classifierOrNull
 import org.jetbrains.kotlin.ir.types.isNullable
 import org.jetbrains.kotlin.ir.util.functions
-import org.jetbrains.kotlin.ir.util.isAnnotationClass
-import org.jetbrains.kotlin.ir.util.isInterface
 import org.jetbrains.kotlin.ir.util.render
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.FqName
@@ -323,21 +319,3 @@ private fun IrBlockBodyBuilder.irCallHashCodeFunction(
         }
     }
 }
-
-private val IrTypeParameter.erasedUpperBound: IrClass
-    get() {
-        // Pick the (necessarily unique) non-interface upper bound if it exists
-        for (type in superTypes) {
-            val irClass = type.classOrNull?.owner ?: continue
-            if (!irClass.isInterface && !irClass.isAnnotationClass) return irClass
-        }
-
-        // Otherwise, choose either the first IrClass supertype or recurse.
-        // In the first case, all supertypes are interface types and the choice was arbitrary.
-        // In the second case, there is only a single supertype.
-        return when (val firstSuper = superTypes.first().classifierOrNull?.owner) {
-            is IrClass -> firstSuper
-            is IrTypeParameter -> firstSuper.erasedUpperBound
-            else -> error("unknown supertype kind $firstSuper")
-        }
-    }

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
@@ -141,9 +141,8 @@ private fun IrBlockBodyBuilder.getHashCodeOf(
 ): IrExpression {
     val hasArrayContentBasedAnnotation = property.hasArrayContentBasedAnnotation()
     val classifier = property.type.classifierOrNull
-    val mayBeRuntimeArray = classifier.mayBeRuntimeArray(context)
 
-    if (hasArrayContentBasedAnnotation && mayBeRuntimeArray) {
+    if (hasArrayContentBasedAnnotation && with(context) { classifier.mayBeRuntimeArray() }) {
         return irRuntimeArrayContentDeepHashCode(value)
     }
 
@@ -233,7 +232,8 @@ private fun IrBlockBodyBuilder.maybeFindArrayDeepHashCodeFunction(
 ): IrSimpleFunctionSymbol? {
     val propertyClassifier = property.type.classifierOrFail
 
-    if (!propertyClassifier.isArrayOrPrimitiveArray(context)) {
+    val isArray = with(context) { propertyClassifier.isArrayOrPrimitiveArray() }
+    if (!isArray) {
         messageCollector.reportErrorOnProperty(
             property = property,
             message = "@ArrayContentBased on property of type <${property.type.render()}> not supported",
@@ -274,7 +274,7 @@ private fun IrBlockBodyBuilder.findArrayContentDeepHashCodeFunction(
 private fun IrBlockBodyBuilder.getStandardHashCodeFunctionSymbol(
     classifier: IrClassifierSymbol?,
 ): IrSimpleFunctionSymbol = when {
-    classifier.isArrayOrPrimitiveArray(context) ->
+    with(context) { classifier.isArrayOrPrimitiveArray() } ->
         context.irBuiltIns.dataClassArrayMemberHashCodeSymbol
     classifier is IrClassSymbol ->
         getHashCodeFunctionForClass(classifier.owner)

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/toStringGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/toStringGeneration.kt
@@ -63,9 +63,8 @@ internal fun IrBlockBodyBuilder.generateToStringMethodBody(
 
         val classifier = property.type.classifierOrNull
         val hasArrayContentBasedAnnotation = property.hasArrayContentBasedAnnotation()
-        val mayBeRuntimeArray = classifier.mayBeRuntimeArray(context)
         val propertyStringValue = when {
-            hasArrayContentBasedAnnotation && mayBeRuntimeArray -> {
+            hasArrayContentBasedAnnotation && with(context) { classifier.mayBeRuntimeArray() } -> {
                 val field = property.backingField!!
                 val instance = irGetField(functionDeclaration.receiver(), field)
                 irRuntimeArrayContentDeepToString(instance)
@@ -82,7 +81,7 @@ internal fun IrBlockBodyBuilder.generateToStringMethodBody(
                 )
             }
 
-            classifier.isArrayOrPrimitiveArray(context) -> {
+            with(context) { classifier.isArrayOrPrimitiveArray() } -> {
                 irCallToStringFunction(
                     toStringFunctionSymbol = context.irBuiltIns.dataClassArrayMemberToStringSymbol,
                     value = propertyValue,
@@ -110,7 +109,8 @@ private fun IrBlockBodyBuilder.maybeFindArrayDeepToStringFunction(
 ): IrSimpleFunctionSymbol? {
     val propertyClassifier = property.type.classifierOrFail
 
-    if (!propertyClassifier.isArrayOrPrimitiveArray(context)) {
+    val isArray = with(context) { propertyClassifier.isArrayOrPrimitiveArray() }
+    if (!isArray) {
         messageCollector.reportErrorOnProperty(
             property = property,
             message = "@ArrayContentBased on property of type <${property.type.render()}> not supported",

--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
@@ -1128,12 +1128,24 @@ class PokoCompilerPluginTest {
         }
     }
 
+    @Test fun `two ComplexGenericArrayHolder instances with equivalent int arrays are equals`() {
+        compareGenericArrayHolderApiInstances(
+            generic1 = intArrayOf(50, 100),
+            generic2 = intArrayOf(50, 100),
+            sourceFileName = "api/ComplexGenericArrayHolder"
+        ) { firstInstance, secondInstance ->
+            assertThat(firstInstance).isEqualTo(secondInstance)
+            assertThat(secondInstance).isEqualTo(firstInstance)
+        }
+    }
+
     private fun compareGenericArrayHolderApiInstances(
         generic1: Any?,
         generic2: Any?,
+        sourceFileName: String = "api/GenericArrayHolder",
         compare: (firstInstance: Any, secondInstance: Any) -> Unit,
     ) = compareTwoInstances(
-        sourceFileName = "api/GenericArrayHolder",
+        sourceFileName = sourceFileName,
         firstInstanceConstructorArgs = listOf(
             Any::class.java to generic1,
         ),

--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
@@ -945,7 +945,7 @@ class PokoCompilerPluginTest {
         }
     }
 
-    @Test fun `two AnyArrayHolder instances holding inequivalent nested typed arrays are not equals`() {
+    @Test fun `two AnyArrayHolder instances holding inequivalent typed arrays are not equals`() {
         compareAnyArrayHolderApiInstances(
             any1 = arrayOf(arrayOf("xx", "xy"), arrayOf("yx", "yy")),
             any2 = arrayOf(arrayOf(1L, 2f), arrayOf(3.0, 4)),
@@ -975,16 +975,6 @@ class PokoCompilerPluginTest {
         }
     }
 
-    @Test fun `compilation reading array content of generic type fails`() {
-        testCompilation(
-            "illegal/GenericArrayHolder",
-            expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR
-        ) { result ->
-            assertThat(result.messages)
-                .contains("@ArrayContentBased on property of type <G of illegal.GenericArrayHolder> not supported")
-        }
-    }
-
     private fun compareAnyArrayHolderApiInstances(
         any1: Any = arrayOf("string A", "string B"),
         nullableAny1: Any? = null,
@@ -1007,20 +997,6 @@ class PokoCompilerPluginTest {
         ),
         compare = compare,
     )
-
-    @Test fun `compilation reading array content of non-arrays fails`() {
-        testCompilation(
-            "illegal/NotArrayHolder",
-            expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR
-        ) { result ->
-            assertThat(result.messages)
-                .contains("@ArrayContentBased on property of type <kotlin.String> not supported")
-            assertThat(result.messages)
-                .contains("@ArrayContentBased on property of type <kotlin.Int> not supported")
-            assertThat(result.messages)
-                .contains("@ArrayContentBased on property of type <kotlin.Float> not supported")
-        }
-    }
 
     @Test fun `AnyArrayHolder has same hashCode as handwritten implementation`() {
         compareApiWithDataClass(
@@ -1045,6 +1021,149 @@ class PokoCompilerPluginTest {
             ),
         ) { apiInstance, dataInstance ->
             assertThat(apiInstance.toString()).isEqualTo(dataInstance.toString())
+        }
+    }
+
+    @Test fun `two GenericArrayHolder instances with equivalent typed arrays are equals`() {
+        compareGenericArrayHolderApiInstances(
+            generic1 = arrayOf(arrayOf("5%, 10%"), intArrayOf(5, 10), booleanArrayOf(false, true)),
+            generic2 = arrayOf(arrayOf("5%, 10%"), intArrayOf(5, 10), booleanArrayOf(false, true)),
+        ) { firstInstance, secondInstance ->
+            assertThat(firstInstance).isEqualTo(secondInstance)
+            assertThat(secondInstance).isEqualTo(firstInstance)
+        }
+    }
+
+    @Test fun `two GenericArrayHolder instances with equivalent typed arrays have same hashCode`() {
+        compareGenericArrayHolderApiInstances(
+            generic1 = arrayOf(arrayOf("5%, 10%"), intArrayOf(5, 10), booleanArrayOf(false, true)),
+            generic2 = arrayOf(arrayOf("5%, 10%"), intArrayOf(5, 10), booleanArrayOf(false, true)),
+        ) { firstInstance, secondInstance ->
+            assertThat(firstInstance.hashCode()).isEqualTo(secondInstance.hashCode())
+        }
+    }
+
+    @Test fun `two GenericArrayHolder instances with equivalent typed arrays have same toString`() {
+        compareGenericArrayHolderApiInstances(
+            generic1 = arrayOf(arrayOf("5%, 10%"), intArrayOf(5, 10), booleanArrayOf(false, true)),
+            generic2 = arrayOf(arrayOf("5%, 10%"), intArrayOf(5, 10), booleanArrayOf(false, true)),
+        ) { firstInstance, secondInstance ->
+            assertThat(firstInstance.toString()).isEqualTo(secondInstance.toString())
+        }
+    }
+
+    @Test fun `two GenericArrayHolder instances with equivalent int arrays are equals`() {
+        compareGenericArrayHolderApiInstances(
+            generic1 = intArrayOf(5, 10),
+            generic2 = intArrayOf(5, 10),
+        ) { firstInstance, secondInstance ->
+            assertThat(firstInstance).isEqualTo(secondInstance)
+            assertThat(secondInstance).isEqualTo(firstInstance)
+        }
+    }
+
+    @Test fun `two GenericArrayHolder instances with equivalent int arrays have same hashCode`() {
+        compareGenericArrayHolderApiInstances(
+            generic1 = intArrayOf(5, 10),
+            generic2 = intArrayOf(5, 10),
+        ) { firstInstance, secondInstance ->
+            assertThat(firstInstance.hashCode()).isEqualTo(secondInstance.hashCode())
+        }
+    }
+
+    @Test fun `two GenericArrayHolder instances with equivalent int arrays have same toString`() {
+        compareGenericArrayHolderApiInstances(
+            generic1 = intArrayOf(5, 10),
+            generic2 = intArrayOf(5, 10),
+        ) { firstInstance, secondInstance ->
+            assertThat(firstInstance.toString()).isEqualTo(secondInstance.toString())
+        }
+    }
+
+    @Test fun `two GenericArrayHolder instances with equivalent non-arrays are equals`() {
+        compareGenericArrayHolderApiInstances(
+            generic1 = "5, 10",
+            generic2 = "5, 10",
+        ) { firstInstance, secondInstance ->
+            assertThat(firstInstance).isEqualTo(secondInstance)
+            assertThat(secondInstance).isEqualTo(firstInstance)
+        }
+    }
+
+    @Test fun `two GenericArrayHolder instances with equivalent non-arrays have same hashCode`() {
+        compareGenericArrayHolderApiInstances(
+            generic1 = "5, 10",
+            generic2 = "5, 10",
+        ) { firstInstance, secondInstance ->
+            assertThat(firstInstance.hashCode()).isEqualTo(secondInstance.hashCode())
+        }
+    }
+
+    @Test fun `two GenericArrayHolder instances with equivalent non-arrays have same toString`() {
+        compareGenericArrayHolderApiInstances(
+            generic1 = "5, 10",
+            generic2 = "5, 10",
+        ) { firstInstance, secondInstance ->
+            assertThat(firstInstance.toString()).isEqualTo(secondInstance.toString())
+        }
+    }
+
+    @Test fun `two GenericArrayHolder instances holding inequivalent long arrays are not equals`() {
+        compareGenericArrayHolderApiInstances(
+            generic1 = longArrayOf(Long.MIN_VALUE),
+            generic2 = longArrayOf(Long.MAX_VALUE),
+        ) { firstInstance, secondInstance ->
+            assertThat(firstInstance).isNotEqualTo(secondInstance)
+            assertThat(secondInstance).isNotEqualTo(firstInstance)
+        }
+    }
+
+    @Test fun `GenericArrayHolder instances holding mismatching types are not equals`() {
+        compareGenericArrayHolderApiInstances(
+            generic1 = arrayOf("x", "y"),
+            generic2 = "xy",
+        ) { firstInstance, secondInstance ->
+            assertThat(firstInstance).isNotEqualTo(secondInstance)
+            assertThat(secondInstance).isNotEqualTo(firstInstance)
+        }
+    }
+
+    private fun compareGenericArrayHolderApiInstances(
+        generic1: Any?,
+        generic2: Any?,
+        compare: (firstInstance: Any, secondInstance: Any) -> Unit,
+    ) = compareTwoInstances(
+        sourceFileName = "api/GenericArrayHolder",
+        firstInstanceConstructorArgs = listOf(
+            Any::class.java to generic1,
+        ),
+        secondInstanceConstructorArgs = listOf(
+            Any::class.java to generic2,
+        ),
+        compare = compare,
+    )
+
+    @Test fun `compilation reading array content of generic type with unsupported upper bound fails`() {
+        testCompilation(
+            "illegal/GenericArrayHolder",
+            expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR
+        ) { result ->
+            assertThat(result.messages)
+                .contains("@ArrayContentBased on property of type <G of illegal.GenericArrayHolder> not supported")
+        }
+    }
+
+    @Test fun `compilation reading array content of non-arrays fails`() {
+        testCompilation(
+            "illegal/NotArrayHolder",
+            expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR
+        ) { result ->
+            assertThat(result.messages)
+                .contains("@ArrayContentBased on property of type <kotlin.String> not supported")
+            assertThat(result.messages)
+                .contains("@ArrayContentBased on property of type <kotlin.Int> not supported")
+            assertThat(result.messages)
+                .contains("@ArrayContentBased on property of type <kotlin.Float> not supported")
         }
     }
     //endregion

--- a/poko-compiler-plugin/src/test/resources/api/ComplexGenericArrayHolder.kt
+++ b/poko-compiler-plugin/src/test/resources/api/ComplexGenericArrayHolder.kt
@@ -1,0 +1,11 @@
+package api
+
+import dev.drewhamilton.poko.ArrayContentBased
+import dev.drewhamilton.poko.ExperimentalArrayContentSupport
+import dev.drewhamilton.poko.Poko
+
+@Suppress("Unused")
+@OptIn(ExperimentalArrayContentSupport::class)
+@Poko class ComplexGenericArrayHolder<A : Any, G : A>(
+    @ArrayContentBased val generic: G,
+)

--- a/poko-compiler-plugin/src/test/resources/api/GenericArrayHolder.kt
+++ b/poko-compiler-plugin/src/test/resources/api/GenericArrayHolder.kt
@@ -1,4 +1,4 @@
-package illegal
+package api
 
 import dev.drewhamilton.poko.ArrayContentBased
 import dev.drewhamilton.poko.ExperimentalArrayContentSupport
@@ -6,6 +6,6 @@ import dev.drewhamilton.poko.Poko
 
 @Suppress("Unused")
 @OptIn(ExperimentalArrayContentSupport::class)
-@Poko class GenericArrayHolder<G : Collection<*>>(
+@Poko class GenericArrayHolder<G>(
     @ArrayContentBased val generic: G,
 )


### PR DESCRIPTION
#1 part 4d: Implements `@ArrayContentBased` support for properties with a generic type (e.g. `T`) that turn out to be arrays at runtime.