### PR TITLE
Update array content documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## SNAPSHOT
+
+Add experimental `@ArrayContentBased` annotation. This annotation can be applied to `@Poko` class
+array properties to ensure that the array's content is considered for `equals`, `hashCode`, and
+`toString`. (By default, array content is not considered.)
+
 ## 0.13.0
 _2023-04-03_
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,24 @@ generate that function but will still generate the non-overridden functions. Usi
 is not recommended, and if they are used, it is recommended to override `equals` and `hashCode`
 manually.
 
+### Arrays
+By default, Poko does nothing to inspect the contents of array properties. [This aligns with data
+classes](https://blog.jetbrains.com/kotlin/2015/09/feedback-request-limitations-on-data-classes/#Appendix.Comparingarrays).
+
+_Note: This feature is currently only available in snapshots._
+Poko consumers can change this behavior on a per-property basis with the `@ArrayContentBased`
+annotation. On properties of a typed array type, this annotation will generate a `contentDeepEquals`
+check. On properties of a primitive array type, this annotation will generate a `contentEquals`
+check. And on properties of type `Any` or of a generic type, this annotation will generate a `when`
+statement that disambiguates the many array types at runtime and uses the appropriate
+`contentDeepEquals` or `contentEquals` check. In all cases, the corresponding content-based
+`hashCode` and `toString` are generated for the property as well.
+
+Using arrays as properties in data types is still not generally recommended: arrays are mutable, and
+mutating data can affect the results of `equals` and `hashCode` over time, which is generally
+unexpected. For this reason, `@ArrayContentBased` should only be used in very performance-sensitive
+APIs.
+
 ### Annotation
 By default, the `dev.drewhamilton.poko.Poko` annotation is used to mark classes for Poko generation.
 If you prefer, you can create a different annotation and supply it to the Gradle  plugin.
@@ -36,6 +54,9 @@ poko {
   pokoAnnotation.set "com.example.MyDataAnnotation"
 }
 ```
+
+Note that this only affects the primary marker annotation. Supplemental annotations such as
+`@ArrayContentBased` do not support customization.
 
 ### Download
 

--- a/poko-annotations/api/poko-annotations.api
+++ b/poko-annotations/api/poko-annotations.api
@@ -1,7 +1,7 @@
 public abstract interface annotation class dev/drewhamilton/poko/ArrayContentBased : java/lang/annotation/Annotation {
 }
 
-public abstract interface annotation class dev/drewhamilton/poko/ExperimentalArrayContentSupport : java/lang/annotation/Annotation {
+public abstract interface annotation class dev/drewhamilton/poko/ArrayContentSupport : java/lang/annotation/Annotation {
 }
 
 public abstract interface annotation class dev/drewhamilton/poko/Poko : java/lang/annotation/Annotation {

--- a/poko-annotations/src/main/kotlin/dev/drewhamilton/poko/ArrayContentBased.kt
+++ b/poko-annotations/src/main/kotlin/dev/drewhamilton/poko/ArrayContentBased.kt
@@ -23,7 +23,7 @@ package dev.drewhamilton.poko
  * different `equals` and `hashCode` results at different times. This annotation should only be used
  * by consumers for whom performant code is more important than safe code.
  */
-@ExperimentalArrayContentSupport
+@ArrayContentSupport
 @Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.PROPERTY)
 public annotation class ArrayContentBased

--- a/poko-annotations/src/main/kotlin/dev/drewhamilton/poko/ArrayContentBased.kt
+++ b/poko-annotations/src/main/kotlin/dev/drewhamilton/poko/ArrayContentBased.kt
@@ -5,13 +5,18 @@ package dev.drewhamilton.poko
  * content. This differs from the Poko class (and data class) default of comparing arrays by
  * reference only.
  *
- * Poko class properties of type [Array], [BooleanArray], [ByteArray], [CharArray], [ShortArray],
+ * Poko class properties of type [Array], [BooleanArray], [CharArray], [ByteArray], [ShortArray],
  * [IntArray], [LongArray], [FloatArray], and [DoubleArray] are supported, including nested
  * [Array] types.
  *
- * Properties of a generic type or of type [Any] that are assigned as arrays at runtime are not
- * currently supported. Properties of a value class type that wraps an array are not supported.
- * Tagging non-array properties with this annotation is an error.
+ * Properties of a generic type or of type [Any] are also supported. For these properties, Poko will
+ * generate a `when` statement that disambiguates the various array types at runtime and analyzes
+ * content if the property is an array. (Note that with this logic, typed arrays will never be
+ * considered equals to primitive arrays, even if they hold the same content. For example,
+ * `arrayOf(1, 2)` will not be considered equals to `intArrayOf(1, 2)`.)
+ *
+ * Properties of a value class type that wraps an array are not supported. Tagging non-array
+ * properties with this annotation is an error.
  *
  * Using array properties in data models is not generally recommended, because they are mutable.
  * Mutating an array marked with this annotation will cause the parent Poko class to produce

--- a/poko-annotations/src/main/kotlin/dev/drewhamilton/poko/ArrayContentSupport.kt
+++ b/poko-annotations/src/main/kotlin/dev/drewhamilton/poko/ArrayContentSupport.kt
@@ -5,4 +5,4 @@ package dev.drewhamilton.poko
  * change or break.
  */
 @RequiresOptIn
-public annotation class ExperimentalArrayContentSupport
+public annotation class ArrayContentSupport

--- a/poko-compiler-plugin/src/test/resources/api/AnyArrayHolder.kt
+++ b/poko-compiler-plugin/src/test/resources/api/AnyArrayHolder.kt
@@ -1,11 +1,11 @@
 package api
 
 import dev.drewhamilton.poko.ArrayContentBased
-import dev.drewhamilton.poko.ExperimentalArrayContentSupport
+import dev.drewhamilton.poko.ArrayContentSupport
 import dev.drewhamilton.poko.Poko
 
 @Suppress("Unused")
-@OptIn(ExperimentalArrayContentSupport::class)
+@OptIn(ArrayContentSupport::class)
 @Poko class AnyArrayHolder(
     @ArrayContentBased val any: Any,
     @ArrayContentBased val nullableAny: Any?,

--- a/poko-compiler-plugin/src/test/resources/api/ArrayHolder.kt
+++ b/poko-compiler-plugin/src/test/resources/api/ArrayHolder.kt
@@ -1,11 +1,11 @@
 package api
 
 import dev.drewhamilton.poko.ArrayContentBased
-import dev.drewhamilton.poko.ExperimentalArrayContentSupport
+import dev.drewhamilton.poko.ArrayContentSupport
 import dev.drewhamilton.poko.Poko
 
 @Suppress("Unused")
-@OptIn(ExperimentalArrayContentSupport::class)
+@OptIn(ArrayContentSupport::class)
 @Poko class ArrayHolder(
     @ArrayContentBased val stringArray: Array<String>,
     @ArrayContentBased val nullableStringArray: Array<String>?,

--- a/poko-compiler-plugin/src/test/resources/api/ComplexGenericArrayHolder.kt
+++ b/poko-compiler-plugin/src/test/resources/api/ComplexGenericArrayHolder.kt
@@ -1,11 +1,11 @@
 package api
 
 import dev.drewhamilton.poko.ArrayContentBased
-import dev.drewhamilton.poko.ExperimentalArrayContentSupport
+import dev.drewhamilton.poko.ArrayContentSupport
 import dev.drewhamilton.poko.Poko
 
 @Suppress("Unused")
-@OptIn(ExperimentalArrayContentSupport::class)
+@OptIn(ArrayContentSupport::class)
 @Poko class ComplexGenericArrayHolder<A : Any, G : A>(
     @ArrayContentBased val generic: G,
 )

--- a/poko-compiler-plugin/src/test/resources/api/GenericArrayHolder.kt
+++ b/poko-compiler-plugin/src/test/resources/api/GenericArrayHolder.kt
@@ -1,11 +1,11 @@
 package api
 
 import dev.drewhamilton.poko.ArrayContentBased
-import dev.drewhamilton.poko.ExperimentalArrayContentSupport
+import dev.drewhamilton.poko.ArrayContentSupport
 import dev.drewhamilton.poko.Poko
 
 @Suppress("Unused")
-@OptIn(ExperimentalArrayContentSupport::class)
+@OptIn(ArrayContentSupport::class)
 @Poko class GenericArrayHolder<G>(
     @ArrayContentBased val generic: G,
 )

--- a/poko-compiler-plugin/src/test/resources/illegal/GenericArrayHolder.kt
+++ b/poko-compiler-plugin/src/test/resources/illegal/GenericArrayHolder.kt
@@ -1,11 +1,11 @@
 package illegal
 
 import dev.drewhamilton.poko.ArrayContentBased
-import dev.drewhamilton.poko.ExperimentalArrayContentSupport
+import dev.drewhamilton.poko.ArrayContentSupport
 import dev.drewhamilton.poko.Poko
 
 @Suppress("Unused")
-@OptIn(ExperimentalArrayContentSupport::class)
+@OptIn(ArrayContentSupport::class)
 @Poko class GenericArrayHolder<G : Collection<*>>(
     @ArrayContentBased val generic: G,
 )

--- a/poko-compiler-plugin/src/test/resources/illegal/NotArrayHolder.kt
+++ b/poko-compiler-plugin/src/test/resources/illegal/NotArrayHolder.kt
@@ -1,11 +1,11 @@
 package illegal
 
-import dev.drewhamilton.poko.ExperimentalArrayContentSupport
+import dev.drewhamilton.poko.ArrayContentSupport
 import dev.drewhamilton.poko.Poko
 import dev.drewhamilton.poko.ArrayContentBased
 
 @Suppress("Unused")
-@OptIn(ExperimentalArrayContentSupport::class)
+@OptIn(ArrayContentSupport::class)
 @Poko class NotArrayHolder(
     @ArrayContentBased val string: String,
     @ArrayContentBased val int: Int,

--- a/poko-gradle-plugin/src/main/kotlin/dev/drewhamilton/poko/gradle/PokoPluginExtension.kt
+++ b/poko-gradle-plugin/src/main/kotlin/dev/drewhamilton/poko/gradle/PokoPluginExtension.kt
@@ -15,6 +15,11 @@ public abstract class PokoPluginExtension @Inject constructor(objects: ObjectFac
      *
      * Note that this must be in the format of a string where packages are delimited by `/` and
      * classes by `.`, e.g. `com/example/Nested.Annotation`.
+     *
+     * Note that this only affects the main Poko annotation. Additional Poko annotations, such as
+     * `@ArrayContentBased`, are not customizable. If a custom Poko marker annotation is defined
+     * _and_ additional Poko annotations are used, the poko-annotations artifact must be manually
+     * added as an `implementation` dependency.
      */
     public val pokoAnnotation: Property<String> = objects.property(String::class.java)
         .convention(DEFAULT_POKO_ANNOTATION)


### PR DESCRIPTION
Updates documentation for the new `@ArrayContentBased` annotation, adding it to the readme and the changelog.

Also renames the opt-in annotation to `@ArrayContentSupport` for brevity.

Closes #1.