### PR TITLE
Source retention

### DIFF
--- a/poko-annotations/src/main/kotlin/dev/drewhamilton/poko/ArrayContentBased.kt
+++ b/poko-annotations/src/main/kotlin/dev/drewhamilton/poko/ArrayContentBased.kt
@@ -24,6 +24,6 @@ package dev.drewhamilton.poko
  * by consumers for whom performant code is more important than safe code.
  */
 @ArrayContentSupport
-@Retention(AnnotationRetention.BINARY)
+@Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.PROPERTY)
 public annotation class ArrayContentBased

--- a/poko-annotations/src/main/kotlin/dev/drewhamilton/poko/Poko.kt
+++ b/poko-annotations/src/main/kotlin/dev/drewhamilton/poko/Poko.kt
@@ -20,6 +20,6 @@ package dev.drewhamilton.poko
  * immutable. `var`s, mutable collections, and especially arrays should be avoided. The class itself
  * should also be final. The compiler plugin does not enforce these recommendations.
  */
-@Retention(AnnotationRetention.BINARY)
+@Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.CLASS)
 public annotation class Poko

--- a/poko-gradle-plugin/src/main/kotlin/dev/drewhamilton/poko/gradle/PokoGradlePlugin.kt
+++ b/poko-gradle-plugin/src/main/kotlin/dev/drewhamilton/poko/gradle/PokoGradlePlugin.kt
@@ -39,7 +39,10 @@ public class PokoGradlePlugin : KotlinCompilerPluginSupportPlugin {
             else -> null
         }
         if (annotationDependency != null) {
-            project.dependencies.add("implementation", annotationDependency)
+            project.dependencies.add(
+                kotlinCompilation.compileOnlyConfigurationName,
+                annotationDependency,
+            )
         }
 
         return project.provider {


### PR DESCRIPTION
Implements #163 (don't want to close until I decide whether to revert this). Converts the default `@Poko` annotation from binary retention to source retention, and adds the poko-annotations dependency as `compileOnly` by default, rather than `implementation`. This makes Poko invisible to consumers of libraries using Poko.

A downside is that such consumers will see `@Poko` ~~highlighted in red~~ (edit: in neutral color) in their IDEs, and won't be able to click through to its doc comments.