### PR TITLE
Change Kotlin compiler dependency to compileOnly

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,6 @@ kotlin-compileTesting = { module = "com.github.tschuchortdev:kotlin-compile-test
 kotlin-compileTestingFork = { module = "dev.zacsweers.kctfork:core", version.ref = "kotlinCompileTestingFork" }
 
 kotlin-embeddableCompiler = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
-kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-gradleApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }
 
 truth = { module = "com.google.truth:truth", version = "1.1.5" }

--- a/poko-gradle-plugin/build.gradle.kts
+++ b/poko-gradle-plugin/build.gradle.kts
@@ -37,7 +37,7 @@ gradlePlugin {
 }
 
 dependencies {
-    implementation(libs.kotlin.gradleApi)
+    compileOnly(libs.kotlin.gradleApi)
 
     implementation(libs.autoService.annotations)
     ksp(libs.autoService.ksp)

--- a/poko-gradle-plugin/build.gradle.kts
+++ b/poko-gradle-plugin/build.gradle.kts
@@ -38,7 +38,6 @@ gradlePlugin {
 
 dependencies {
     implementation(libs.kotlin.gradleApi)
-    compileOnly(libs.kotlin.gradle)
 
     implementation(libs.autoService.annotations)
     ksp(libs.autoService.ksp)


### PR DESCRIPTION
Consumers of poko-gradle-plugin are plugging Poko into a Kotlin compilation, not the other way around. They are expected to apply kotlin-gradle-plugin independently, rather than relying on Poko to pull it in. It's very unlikely that any Poko consumers are not already doing this.

Practically speaking, the goal of this is to ensure that consumers using a compatible version of Kotlin older than the one used to compile Poko are not forced to a newer version. For example, projects compiling with Kotlin 1.8.21 should be able to use Poko 0.13.2 without being forced to Kotlin 1.8.22.