### PR TITLE
Migrate to AssertK

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ kotlin-compileTestingFork = { module = "dev.zacsweers.kctfork:core", version.ref
 kotlin-embeddableCompiler = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
 kotlin-gradleApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }
 
-truth = { module = "com.google.truth:truth", version = "1.1.5" }
+assertk = "com.willowtreeapps.assertk:assertk:0.26.1"
 
 [plugins]
 

--- a/poko-compiler-plugin/build.gradle.kts
+++ b/poko-compiler-plugin/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
     testImplementation(libs.kotlin.embeddableCompiler)
     testImplementation(libs.kotlin.compileTesting)
     testImplementation(libs.junit)
-    testImplementation(libs.truth)
+    testImplementation(libs.assertk)
 }
 
 kotlin {

--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
@@ -1,6 +1,9 @@
 package dev.drewhamilton.poko
 
-import com.google.common.truth.Truth.assertThat
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEqualTo
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.PluginOption
 import com.tschuchort.compiletesting.SourceFile

--- a/poko-gradle-plugin/build.gradle.kts
+++ b/poko-gradle-plugin/build.gradle.kts
@@ -43,5 +43,5 @@ dependencies {
     ksp(libs.autoService.ksp)
 
     testImplementation(libs.junit)
-    testImplementation(libs.truth)
+    testImplementation(libs.assertk)
 }

--- a/sample/compose/build.gradle.kts
+++ b/sample/compose/build.gradle.kts
@@ -59,7 +59,7 @@ dependencies {
     implementation(libs.androidx.compose.runtime)
 
     testImplementation(libs.junit)
-    testImplementation(libs.truth)
+    testImplementation(libs.assertk)
 }
 
 repositories {

--- a/sample/compose/src/test/kotlin/dev/drewhamilton/poko/sample/compose/SampleTest.kt
+++ b/sample/compose/src/test/kotlin/dev/drewhamilton/poko/sample/compose/SampleTest.kt
@@ -1,6 +1,7 @@
 package dev.drewhamilton.poko.sample.compose
 
-import com.google.common.truth.Truth.assertThat
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import org.junit.Test
 
 class SampleTest {

--- a/sample/jvm/build.gradle.kts
+++ b/sample/jvm/build.gradle.kts
@@ -9,5 +9,5 @@ poko {
 
 dependencies {
     testImplementation(libs.junit)
-    testImplementation(libs.truth)
+    testImplementation(libs.assertk)
 }

--- a/sample/jvm/src/test/kotlin/dev/drewhamilton/poko/sample/jvm/SampleTest.kt
+++ b/sample/jvm/src/test/kotlin/dev/drewhamilton/poko/sample/jvm/SampleTest.kt
@@ -1,6 +1,7 @@
 package dev.drewhamilton.poko.sample.jvm
 
-import com.google.common.truth.Truth.assertThat
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import org.junit.Test
 
 class SampleTest {

--- a/sample/jvm/src/test/kotlin/dev/drewhamilton/poko/sample/jvm/arrays/ArrayTest.kt
+++ b/sample/jvm/src/test/kotlin/dev/drewhamilton/poko/sample/jvm/arrays/ArrayTest.kt
@@ -1,6 +1,9 @@
 package dev.drewhamilton.poko.sample.jvm.arrays
 
-import com.google.common.truth.Truth.assertThat
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEqualTo
+import assertk.assertions.matches
 import org.junit.Test
 
 class ArrayTest {
@@ -109,7 +112,7 @@ class ArrayTest {
         val expected = Regex(
             "DataArrayHolder\\(id=id, array=\\[one, two], maybe=\\[Ljava.lang.String;@[0-9a-fA-F]+\\)"
         )
-        assertThat(a.toString()).matches(expected.toPattern())
+        assertThat(a.toString()).matches(expected)
     }
 
     @Test fun `handwritten toString is as expected`() {
@@ -122,7 +125,7 @@ class ArrayTest {
         val expected = Regex(
             "HandwrittenArrayHolder\\(id=id, array=\\[one, two], maybe=\\[Ljava.lang.String;@[0-9a-fA-F]+\\)"
         )
-        assertThat(a.toString()).matches(expected.toPattern())
+        assertThat(a.toString()).matches(expected)
     }
 
     @Test fun `poko toString is as expected`() {
@@ -135,7 +138,7 @@ class ArrayTest {
         val expected = Regex(
             "PokoArrayHolder\\(id=id, array=\\[one, two], maybe=\\[Ljava.lang.String;@[0-9a-fA-F]+\\)"
         )
-        assertThat(a.toString()).matches(expected.toPattern())
+        assertThat(a.toString()).matches(expected)
     }
     //endregion
 }


### PR DESCRIPTION
It has Truth-like API but supports the forthcoming multiplatform migration where Truth is only a JVM/Android library.

Refs #142 