### PR TITLE
Simplify setup of `ArtifactInfo` template copy

### DIFF
--- a/buildSrc/src/main/java/dev/drewhamilton/poko/build/info.kt
+++ b/buildSrc/src/main/java/dev/drewhamilton/poko/build/info.kt
@@ -1,9 +1,7 @@
 package dev.drewhamilton.poko.build
 
-import kotlin.reflect.KClass
 import org.gradle.api.Action
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.SourceSetContainer
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
@@ -15,41 +13,29 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
  */
 fun Project.generateArtifactInfo(
     basePackage: String,
-    vararg dependentTasks: KClass<out Task>,
 ) {
-    val taskName = "generateArtifactInfo"
-    val genDir: String = "generated/source/artifact-info-template/main"
     val generateArtifactInfoProvider = tasks.register(
-        taskName,
+        "generateArtifactInfo",
         Copy::class.java,
-        GenerateArtifactInfoAction(this, genDir, basePackage),
+        GenerateArtifactInfoAction(this, basePackage),
     )
+    generateArtifactInfoProvider.configure {
+        from(rootProject.layout.projectDirectory.dir("artifact-info-template"))
+        into(layout.buildDirectory.dir("generated/source/artifact-info-template/main"))
+    }
 
     sourceSets {
-        getByName("main").java.srcDir("$buildDir/$genDir")
-    }
-
-    tasks.withType(KotlinCompilationTask::class.java).configureEach {
-        dependsOn(generateArtifactInfoProvider)
-    }
-
-    dependentTasks.forEach { taskType ->
-        tasks.withType(taskType.java).configureEach {
-            dependsOn(taskName)
-        }
+        getByName("main").java.srcDir(generateArtifactInfoProvider)
     }
 }
 
 @PublishedApi
 internal class GenerateArtifactInfoAction(
     private val project: Project,
-    private val genDir: String,
     private val basePackage: String,
 ) : Action<Copy> {
 
     override fun execute(t: Copy) {
-        t.from(project.rootProject.layout.projectDirectory.dir("artifact-info-template"))
-        t.into(project.layout.buildDirectory.dir(genDir))
         t.expand(
             mapOf(
                 "basePackage" to basePackage,

--- a/buildSrc/src/main/java/dev/drewhamilton/poko/build/info.kt
+++ b/buildSrc/src/main/java/dev/drewhamilton/poko/build/info.kt
@@ -8,8 +8,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 /**
  * Generates an `ArtifactInfo` class with information about the Poko artifacts in [basePackage] in the calling Project.
- * Tasks of type [KotlinCompilationTask] will depend on the generation task's provider, and each of [dependentTasks]
- * will depend on the generation task directly.
  */
 fun Project.generateArtifactInfo(
     basePackage: String,

--- a/poko-compiler-plugin/build.gradle.kts
+++ b/poko-compiler-plugin/build.gradle.kts
@@ -1,6 +1,4 @@
-import com.google.devtools.ksp.gradle.KspTask
 import dev.drewhamilton.poko.build.generateArtifactInfo
-import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -13,7 +11,6 @@ plugins {
 
 generateArtifactInfo(
     basePackage = "dev.drewhamilton.poko",
-    DokkaTask::class, Jar::class, KspTask::class,
 )
 
 dependencies {

--- a/poko-gradle-plugin/build.gradle.kts
+++ b/poko-gradle-plugin/build.gradle.kts
@@ -1,6 +1,4 @@
-import com.google.devtools.ksp.gradle.KspTask
 import dev.drewhamilton.poko.build.generateArtifactInfo
-import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -14,7 +12,6 @@ plugins {
 
 generateArtifactInfo(
     basePackage = "dev.drewhamilton.poko.gradle",
-    DokkaTask::class, Jar::class, KspTask::class,
 )
 
 kotlin {


### PR DESCRIPTION
Remove automatic task wiring in favor of implicit wiring by adding the `Copy` task directly as a source folder. Gradle will interrogate the task for its `@OutputDirectory` and add that as a source folder along with a dependency on the task for anyone who consumes the source folders.