### PR TITLE
Remove redundant feature disabling and add one more

### DIFF
--- a/sample/compose/build.gradle.kts
+++ b/sample/compose/build.gradle.kts
@@ -43,11 +43,9 @@ android {
         compose = true
 
         // Disable unused AGP features
-        buildConfig = false
-        aidl = false
-        renderScript = false
         resValues = false
         shaders = false
+        androidResources = false
     }
 
     composeOptions {


### PR DESCRIPTION
Before:

    $ gw -p sample :compose:build --dry-run --console=plain | grep SKIPPED | wc -l
      89

After deleting redundant disabling:

    $ gw -p sample :compose:build --dry-run --console=plain | grep SKIPPED | wc -l
      89

After adding `androidResources = false`:

    $ gw -p sample :compose:build --dry-run --console=plain | grep SKIPPED | wc -l
      76