### PR TITLE
Add support for excludeFunctions

### DIFF
--- a/poko-annotations/src/commonMain/kotlin/dev/drewhamilton/poko/Poko.kt
+++ b/poko-annotations/src/commonMain/kotlin/dev/drewhamilton/poko/Poko.kt
@@ -22,4 +22,6 @@ package dev.drewhamilton.poko
  */
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.CLASS)
-public annotation class Poko
+public annotation class Poko(
+    val excludeFunctions: Boolean = false
+)

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoData.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoData.kt
@@ -1,0 +1,4 @@
+package dev.drewhamilton.poko.ir
+
+/** Metadata read from Poko annotations. */
+internal data class PokoData(val excludeFunctions: Boolean)

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
@@ -3,6 +3,7 @@ package dev.drewhamilton.poko.ir
 import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
+import org.jetbrains.kotlin.backend.jvm.ir.getValueArgument
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.descriptors.impl.LazyClassReceiverParameterDescriptor
 import org.jetbrains.kotlin.ir.IrStatement
@@ -15,13 +16,22 @@ import org.jetbrains.kotlin.ir.declarations.IrProperty
 import org.jetbrains.kotlin.ir.declarations.impl.IrValueParameterImpl
 import org.jetbrains.kotlin.ir.declarations.isMultiFieldValueClass
 import org.jetbrains.kotlin.ir.declarations.isSingleFieldValueClass
+import org.jetbrains.kotlin.ir.expressions.IrClassReference
+import org.jetbrains.kotlin.ir.expressions.IrConst
+import org.jetbrains.kotlin.ir.expressions.IrConstKind
+import org.jetbrains.kotlin.ir.expressions.IrConstantValue
+import org.jetbrains.kotlin.ir.expressions.IrVararg
 import org.jetbrains.kotlin.ir.symbols.impl.IrValueParameterSymbolImpl
 import org.jetbrains.kotlin.ir.types.createType
-import org.jetbrains.kotlin.ir.util.hasAnnotation
+import org.jetbrains.kotlin.ir.types.isArray
+import org.jetbrains.kotlin.ir.types.isBoolean
+import org.jetbrains.kotlin.ir.util.getAnnotation
 import org.jetbrains.kotlin.ir.util.isFakeOverride
+import org.jetbrains.kotlin.ir.util.isFunction
 import org.jetbrains.kotlin.ir.util.primaryConstructor
 import org.jetbrains.kotlin.ir.util.properties
 import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.resolve.source.getPsi
 
@@ -35,10 +45,12 @@ internal class PokoMembersTransformer(
         messageCollector.log("Reading <$declaration>")
 
         val declarationParent = declaration.parent
-        if (declarationParent is IrClass && declarationParent.isPokoClass() && declaration.isFakeOverride) {
+        if (declarationParent !is IrClass || !declaration.isFakeOverride) return declaration
+        val pokoData = declarationParent.pokoData()
+        if (pokoData != null) {
             with(pluginContext) {
                 when {
-                    declaration.isEquals() -> declaration.convertToGenerated { properties ->
+                    declaration.isEquals() -> declaration.convertToGenerated(pokoData) { properties ->
                         generateEqualsMethodBody(
                             irClass = declarationParent,
                             functionDeclaration = declaration,
@@ -47,7 +59,7 @@ internal class PokoMembersTransformer(
                         )
                     }
 
-                    declaration.isHashCode() -> declaration.convertToGenerated { properties ->
+                    declaration.isHashCode() -> declaration.convertToGenerated(pokoData) { properties ->
                         generateHashCodeMethodBody(
                             functionDeclaration = declaration,
                             classProperties = properties,
@@ -55,7 +67,7 @@ internal class PokoMembersTransformer(
                         )
                     }
 
-                    declaration.isToString() -> declaration.convertToGenerated { properties ->
+                    declaration.isToString() -> declaration.convertToGenerated(pokoData) { properties ->
                         generateToStringMethodBody(
                             irClass = declarationParent,
                             functionDeclaration = declaration,
@@ -70,50 +82,78 @@ internal class PokoMembersTransformer(
         return super.visitFunctionNew(declaration)
     }
 
-    private fun IrClass.isPokoClass(): Boolean = when {
-        !hasAnnotation(pokoAnnotationName.asSingleFqName()) -> {
-            messageCollector.log("Not Poko class")
-            false
-        }
-        isData -> {
-            messageCollector.log("Data class")
-            messageCollector.reportErrorOnClass(this, "Poko does not support data classes")
-            false
-        }
-        isSingleFieldValueClass || isMultiFieldValueClass -> {
-            messageCollector.log("Value class")
-            messageCollector.reportErrorOnClass(this, "Poko does not support value classes")
-            false
-        }
-        isInner -> {
-            messageCollector.log("Inner class")
-            messageCollector.reportErrorOnClass(this, "Poko cannot be applied to inner classes")
-            false
-        }
-        primaryConstructor == null -> {
-            messageCollector.log("No primary constructor")
-            messageCollector.reportErrorOnClass(
-                irClass = this,
-                message = "Poko classes must have a primary constructor",
-            )
-            false
-        }
-        else -> {
-            true
+    /**
+     * If a poko annotation is found, validates it and returns associated [PokoData] for it.
+     *
+     * If this returns null, no poko annotation was found.
+     */
+    private fun IrClass.pokoData(): PokoData? {
+        val annotation = getAnnotation(pokoAnnotationName.asSingleFqName())
+        return when {
+            annotation == null -> {
+                messageCollector.log("Not Poko class")
+                null
+            }
+            isData -> {
+                messageCollector.log("Data class")
+                messageCollector.reportErrorOnClass(this, "Poko does not support data classes")
+                null
+            }
+            isSingleFieldValueClass || isMultiFieldValueClass -> {
+                messageCollector.log("Value class")
+                messageCollector.reportErrorOnClass(this, "Poko does not support value classes")
+                null
+            }
+            isInner -> {
+                messageCollector.log("Inner class")
+                messageCollector.reportErrorOnClass(this, "Poko cannot be applied to inner classes")
+                null
+            }
+            primaryConstructor == null -> {
+                messageCollector.log("No primary constructor")
+                messageCollector.reportErrorOnClass(
+                    irClass = this,
+                    message = "Poko classes must have a primary constructor",
+                )
+                null
+            }
+            else -> {
+                val excludeFunctionsArg = annotation.getValueArgument(Name.identifier("excludeFunctions"))
+                val excludeFunctions = if (excludeFunctionsArg != null) {
+                    if (excludeFunctionsArg !is IrConst<*> || excludeFunctionsArg.kind !is IrConstKind.Boolean) {
+                        messageCollector.log("Wrong type for excludeFunctions")
+                        messageCollector.reportErrorOnClass(
+                            irClass = this,
+                            message = "excludeFunctions property on Poko annotations must be a Boolean type",
+                        )
+                        return null
+                    }
+                    @Suppress("UNCHECKED_CAST")
+                    (excludeFunctionsArg as IrConst<Boolean>).value
+                } else {
+                    false
+                }
+                PokoData(excludeFunctions)
+            }
         }
     }
 
     private inline fun IrFunction.convertToGenerated(
+        pokoData: PokoData,
         generateFunctionBody: IrBlockBodyBuilder.(List<IrProperty>) -> Unit
     ) {
         val parent = parent as IrClass
         val properties = parent.properties
-            .toList()
+            .filter {
+                // Filter out function properties if requested
+                !(pokoData.excludeFunctions && it.type.isFunction())
+            }
             .filter {
                 // Can't figure out how to check this another way. FIR?
                 @OptIn(ObsoleteDescriptorBasedAPI::class)
                 it.symbol.descriptor.source.getPsi() is KtParameter
             }
+            .toList()
         if (properties.isEmpty()) {
             messageCollector.log("No primary constructor properties")
             messageCollector.reportErrorOnClass(

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
@@ -16,15 +16,10 @@ import org.jetbrains.kotlin.ir.declarations.IrProperty
 import org.jetbrains.kotlin.ir.declarations.impl.IrValueParameterImpl
 import org.jetbrains.kotlin.ir.declarations.isMultiFieldValueClass
 import org.jetbrains.kotlin.ir.declarations.isSingleFieldValueClass
-import org.jetbrains.kotlin.ir.expressions.IrClassReference
 import org.jetbrains.kotlin.ir.expressions.IrConst
 import org.jetbrains.kotlin.ir.expressions.IrConstKind
-import org.jetbrains.kotlin.ir.expressions.IrConstantValue
-import org.jetbrains.kotlin.ir.expressions.IrVararg
 import org.jetbrains.kotlin.ir.symbols.impl.IrValueParameterSymbolImpl
 import org.jetbrains.kotlin.ir.types.createType
-import org.jetbrains.kotlin.ir.types.isArray
-import org.jetbrains.kotlin.ir.types.isBoolean
 import org.jetbrains.kotlin.ir.util.getAnnotation
 import org.jetbrains.kotlin.ir.util.isFakeOverride
 import org.jetbrains.kotlin.ir.util.isFunction


### PR DESCRIPTION
This is a proposal PR for supporting extra signaling/metadata in poko annotations for `excludeFunctions` (and leaving a toe-hold for future such configurations).

The intention behind this is that some types, such as Kotlin function types, are known not to have true equality and should be ignored. This especially comes to a head in compose, where capturing lambdas for objects with state become a major headache (https://issuetracker.google.com/issues/256100927).

This is a proposal for how this could look, where both the first-party `@Poko` annotation and any other custom ones could implement this. The idea is that a custom annotation could offer this with its own default. We could also even remove this from `@Poko` and only leave it as an optional control for custom annotations.

If this looks acceptable, I'll proceed with adding tests too.