### PR TITLE
Revert CI build-sample to Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           if-no-files-found: error
 
   build-sample:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     needs: build
     strategy:
       matrix:


### PR DESCRIPTION
The main project build needs MacOS now to support all targets (#179), but the sample is still JVM-only for now. That will change soon, but until then we may as well retain the high parallelism that GitHub allows for Ubuntu machines.