### PR TITLE
Add stdlib to dependencies ignored by Renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -18,8 +18,9 @@
     },
   ],
   "ignoreDeps": [
+    // These should just match the main Kotlin version:
     "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-    "org.jetbrains.kotlin:kotlin-gradle-plugin",
     "org.jetbrains.kotlin:kotlin-gradle-plugin-api",
+    "org.jetbrains.kotlin:kotlin-stdlib",
   ],
 }


### PR DESCRIPTION
We don't want weird versions like #185. Renovate is already using the regular Kotlin version for this (and the other ignored Kotlin-related deps).