### PR TITLE
Move publishing configuration mostly into the build plugin

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,12 +1,12 @@
 # Releasing
 
  1. Make sure you're on the main branch.
- 2. Change `VERSION_NAME` in gradle.properties to a non-SNAPSHOT version.
+ 2. Change `pokoVersion` in `build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildPlugin.kt` to a non-SNAPSHOT version.
  3. Update README.md for the impending release.
  4. Update CHANGELOG.md for the impending release.
  5. Commit (don't push) the changes with message "Release x.y.z", where x.y.z is the new version.
  6. Tag the commit `x.y.z`, where x.y.z is the new version.
- 7. Change `VERSION_NAME` in gradle.properties to the next SNAPSHOT version.
+ 7. Change `pokoVersion` in `build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildPlugin.kt` to the next SNAPSHOT version.
  8. Commit the snapshot change.
  9. Push the tag and 2 commits to origin/main.
 10. Wait for the "Release" Action to complete.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,7 @@
 # Releasing
 
  1. Make sure you're on the main branch.
- 2. Change `pokoVersion` in `build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildPlugin.kt` to a non-SNAPSHOT version.
+ 2. Change `pokoVersion` in `build-support/…/PokoBuildPlugin.kt` to a non-SNAPSHOT version.
  3. Update README.md for the impending release.
  4. Update CHANGELOG.md for the impending release.
  5. Commit (don't push) the changes with message "Release x.y.z", where x.y.z is the new version.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,7 +6,7 @@
  4. Update CHANGELOG.md for the impending release.
  5. Commit (don't push) the changes with message "Release x.y.z", where x.y.z is the new version.
  6. Tag the commit `x.y.z`, where x.y.z is the new version.
- 7. Change `pokoVersion` in `build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildPlugin.kt` to the next SNAPSHOT version.
+ 7. Change `pokoVersion` in `build-support/…/PokoBuildPlugin.kt` to the next SNAPSHOT version.
  8. Commit the snapshot change.
  9. Push the tag and 2 commits to origin/main.
 10. Wait for the "Release" Action to complete.

--- a/artifact-info-template/ArtifactInfo.kt
+++ b/artifact-info-template/ArtifactInfo.kt
@@ -6,5 +6,4 @@ internal object ArtifactInfo {
 
     const val ANNOTATIONS_ARTIFACT = "$annotationsArtifact"
     const val COMPILER_PLUGIN_ARTIFACT = "$compilerPluginArtifact"
-    const val GRADLE_PLUGIN_ARTIFACT = "$gradlePluginArtifact"
 }

--- a/build-support/build.gradle.kts
+++ b/build-support/build.gradle.kts
@@ -9,6 +9,8 @@ repositories {
 
 dependencies {
     implementation(libs.kotlin.gradleApi)
+    implementation(libs.plugin.mavenPublish)
+    implementation(libs.plugin.dokka)
 }
 
 gradlePlugin {

--- a/build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildExtension.kt
+++ b/build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildExtension.kt
@@ -1,6 +1,6 @@
 package dev.drewhamilton.poko.build
 
 interface PokoBuildExtension {
-    fun publishing()
+    fun publishing(pomDescription: String)
     fun generateArtifactInfo(basePackage: String)
 }

--- a/build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildPlugin.kt
+++ b/build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildPlugin.kt
@@ -1,5 +1,6 @@
 package dev.drewhamilton.poko.build
 
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -9,9 +10,15 @@ import org.gradle.api.tasks.SourceSetContainer
 import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
 import org.jetbrains.kotlin.gradle.dsl.KotlinTopLevelExtensionConfig
 
+private const val pokoGroupId = "dev.drewhamilton.poko"
+private const val pokoVersion = "0.15.0-SNAPSHOT"
+
 @Suppress("unused") // Invoked reflectively by Gradle.
 class PokoBuildPlugin : Plugin<Project> {
     override fun apply(target: Project) {
+        target.group = pokoGroupId
+        target.version = pokoVersion
+
         target.extensions.add(
             PokoBuildExtension::class.java,
             "pokoBuild",
@@ -28,9 +35,19 @@ class PokoBuildPlugin : Plugin<Project> {
     }
 
     private class PokoBuildExtensionImpl(private val project: Project) : PokoBuildExtension {
-        override fun publishing() {
-            // TODO Use version catalog references here.
+        override fun publishing(pomDescription: String) {
             project.pluginManager.apply("com.vanniktech.maven.publish")
+
+            val mavenPublishing = project.extensions.getByName("mavenPublishing") as MavenPublishBaseExtension
+            @Suppress("UnstableApiUsage")
+            mavenPublishing.apply {
+                coordinates(pokoGroupId, project.name, pokoVersion)
+
+                pom {
+                    description.set(pomDescription)
+                }
+            }
+
             project.pluginManager.apply("org.jetbrains.dokka")
 
             // Published modules should be explicit about their API visibility.
@@ -48,7 +65,7 @@ class PokoBuildPlugin : Plugin<Project> {
             val generateArtifactInfoProvider = project.tasks.register(
                 "generateArtifactInfo",
                 Copy::class.java,
-                GenerateArtifactInfoAction(project, basePackage),
+                GenerateArtifactInfoAction(basePackage),
             )
             generateArtifactInfoProvider.configure {
                 from(project.rootProject.layout.projectDirectory.dir("artifact-info-template"))
@@ -60,25 +77,19 @@ class PokoBuildPlugin : Plugin<Project> {
         }
 
         class GenerateArtifactInfoAction(
-            private val project: Project,
             private val basePackage: String,
         ) : Action<Copy> {
             override fun execute(t: Copy) {
                 t.expand(
                     mapOf(
                         "basePackage" to basePackage,
-                        "publishGroup" to "${project.group}",
-                        "publishVersion" to "${project.version}",
-                        "annotationsArtifact" to artifactIdForProject("poko-annotations"),
-                        "compilerPluginArtifact" to artifactIdForProject("poko-compiler-plugin"),
-                        "gradlePluginArtifact" to artifactIdForProject("poko-gradle-plugin"),
+                        "publishGroup" to pokoGroupId,
+                        "publishVersion" to pokoVersion,
+                        "annotationsArtifact" to "poko-annotations",
+                        "compilerPluginArtifact" to "poko-compiler-plugin",
                     )
                 )
                 t.filteringCharset = "UTF-8"
-            }
-
-            private fun artifactIdForProject(projectName: String): Any {
-                return project.rootProject.project(projectName).property("POM_ARTIFACT_ID")!!
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,8 +3,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    alias(libs.plugins.dokka) apply false
-    alias(libs.plugins.mavenPublish) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.kotlinx.binaryCompatibilityValidator)
@@ -12,8 +10,6 @@ plugins {
 }
 
 allprojects {
-    group = rootProject.property("GROUP")!!
-    version = rootProject.property("VERSION_NAME")!!
     setUpLocalSigning()
 
     repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,5 @@
 kotlin.code.style=official
 
-GROUP=dev.drewhamilton.poko
-VERSION_NAME=0.15.0-SNAPSHOT
-
 #region More publish info
 RELEASE_SIGNING_ENABLED=true
 SONATYPE_HOST=DEFAULT

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,13 +27,14 @@ kotlin-gradleApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", v
 
 assertk = "com.willowtreeapps.assertk:assertk:0.26.1"
 
+plugin-mavenPublish = "com.vanniktech:gradle-maven-publish-plugin:0.25.3"
+plugin-dokka = "org.jetbrains.dokka:dokka-gradle-plugin:1.8.20"
+
 [plugins]
 
 android-library = { id = "com.android.library", version = "8.0.2" }
-dokka = { id = "org.jetbrains.dokka", version = "1.8.20" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinx-binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.13.2" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.25.3" }

--- a/poko-annotations/build.gradle.kts
+++ b/poko-annotations/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 pokoBuild {
-  publishing()
+  publishing("Poko Annotations")
 }
 
 kotlin {

--- a/poko-annotations/gradle.properties
+++ b/poko-annotations/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=poko-annotations
-POM_NAME=Poko Annotations

--- a/poko-compiler-plugin/build.gradle.kts
+++ b/poko-compiler-plugin/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 pokoBuild {
-    publishing()
+    publishing("Poko Compiler Plugin")
     generateArtifactInfo("dev.drewhamilton.poko")
 }
 

--- a/poko-compiler-plugin/gradle.properties
+++ b/poko-compiler-plugin/gradle.properties
@@ -1,5 +1,2 @@
-POM_ARTIFACT_ID=poko-compiler-plugin
-POM_NAME=Poko Compiler Plugin
-
 # We want the stdlib as a compileOnly dependency.
 kotlin.stdlib.default.dependency=false

--- a/poko-gradle-plugin/build.gradle.kts
+++ b/poko-gradle-plugin/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 pokoBuild {
-    publishing()
+    publishing("Poko Gradle Plugin")
     generateArtifactInfo("dev.drewhamilton.poko.gradle")
 }
 

--- a/poko-gradle-plugin/gradle.properties
+++ b/poko-gradle-plugin/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=poko-gradle-plugin
-POM_NAME=Poko Gradle Plugin


### PR DESCRIPTION
This removes the reliance on magic properties in favor of code.

Tested with `publishToMavenLocal`.