### PR TITLE
Only do binary validation on published modules

### DIFF
--- a/build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildPlugin.kt
+++ b/build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildPlugin.kt
@@ -32,6 +32,7 @@ class PokoBuildPlugin : Plugin<Project> {
             // TODO Use version catalog references here.
             project.pluginManager.apply("com.vanniktech.maven.publish")
             project.pluginManager.apply("org.jetbrains.dokka")
+            project.pluginManager.apply("org.jetbrains.kotlinx.binary-compatibility-validator")
 
             // Published modules should be explicit about their API visibility.
             val kotlinPluginHandler = Action<AppliedPlugin> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     alias(libs.plugins.mavenPublish) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.multiplatform) apply false
-    alias(libs.plugins.kotlinx.binaryCompatibilityValidator)
+    alias(libs.plugins.kotlinx.binaryCompatibilityValidator) apply false
     alias(libs.plugins.ksp) apply false
 }
 


### PR DESCRIPTION
I'm adding a `poko-tests` module whose main source set holds the test classes and those test source set does the assertions on them. This new module should not have its ABI validated. Also if we move the samples into the main build (not strictly required, actually) they shouldn't have their ABI validated.

Proof it still works:
```
$ gb --dry-run --console=plain | \grep -i apicheck
:poko-annotations:jvmApiCheck SKIPPED
:poko-annotations:apiCheck SKIPPED
:poko-compiler-plugin:apiCheck SKIPPED
:poko-gradle-plugin:apiCheck SKIPPED
```