### PR TITLE
Allow compiler plugin to be used without arguments

### DIFF
--- a/artifact-info-template/ArtifactInfo.kt
+++ b/artifact-info-template/ArtifactInfo.kt
@@ -7,4 +7,7 @@ internal object ArtifactInfo {
     const val ANNOTATIONS_ARTIFACT = "$annotationsArtifact"
     const val COMPILER_PLUGIN_ARTIFACT = "$compilerPluginArtifact"
     const val GRADLE_PLUGIN_ARTIFACT = "$gradlePluginArtifact"
+
+    const val DEFAULT_POKO_ENABLED = true
+    const val DEFAULT_POKO_ANNOTATION = "dev/drewhamilton/poko/Poko"
 }

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCommandLineProcessor.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCommandLineProcessor.kt
@@ -14,8 +14,8 @@ public class PokoCommandLineProcessor : CommandLineProcessor {
     override val pluginId: String = ArtifactInfo.COMPILER_PLUGIN_ARTIFACT
 
     override val pluginOptions: Collection<AbstractCliOption> = listOf(
-        CliOption(CompilerOptions.ENABLED.toString(), "<true|false>", "", required = true),
-        CliOption(CompilerOptions.POKO_ANNOTATION.toString(), "Annotation class name", "", required = true),
+        CliOption(CompilerOptions.ENABLED.toString(), "<true|false>", "", required = false),
+        CliOption(CompilerOptions.POKO_ANNOTATION.toString(), "Annotation class name", "", required = false),
     )
 
     override fun processOption(

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCompilerPluginRegistrar.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCompilerPluginRegistrar.kt
@@ -1,6 +1,8 @@
 package dev.drewhamilton.poko
 
 import com.google.auto.service.AutoService
+import dev.drewhamilton.poko.ArtifactInfo.DEFAULT_POKO_ANNOTATION
+import dev.drewhamilton.poko.ArtifactInfo.DEFAULT_POKO_ENABLED
 import dev.drewhamilton.poko.ir.PokoIrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
@@ -18,10 +20,10 @@ public class PokoCompilerPluginRegistrar : CompilerPluginRegistrar() {
     override val supportsK2: Boolean = false
 
     override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
-        if (configuration[CompilerOptions.ENABLED] != true)
+        if (!configuration.get(CompilerOptions.ENABLED, DEFAULT_POKO_ENABLED))
             return
 
-        val pokoAnnotationString = checkNotNull(configuration[CompilerOptions.POKO_ANNOTATION])
+        val pokoAnnotationString = configuration.get(CompilerOptions.POKO_ANNOTATION, DEFAULT_POKO_ANNOTATION)
         val pokoAnnotationClassId = ClassId.fromString(pokoAnnotationString)
         val messageCollector = configuration.get(
             CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY,

--- a/poko-gradle-plugin/src/main/kotlin/dev/drewhamilton/poko/gradle/Annotations.kt
+++ b/poko-gradle-plugin/src/main/kotlin/dev/drewhamilton/poko/gradle/Annotations.kt
@@ -1,3 +1,0 @@
-package dev.drewhamilton.poko.gradle
-
-internal const val DEFAULT_POKO_ANNOTATION = "dev/drewhamilton/poko/Poko"

--- a/poko-gradle-plugin/src/main/kotlin/dev/drewhamilton/poko/gradle/PokoGradlePlugin.kt
+++ b/poko-gradle-plugin/src/main/kotlin/dev/drewhamilton/poko/gradle/PokoGradlePlugin.kt
@@ -1,5 +1,6 @@
 package dev.drewhamilton.poko.gradle
 
+import dev.drewhamilton.poko.gradle.ArtifactInfo.DEFAULT_POKO_ANNOTATION
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation

--- a/poko-gradle-plugin/src/main/kotlin/dev/drewhamilton/poko/gradle/PokoPluginExtension.kt
+++ b/poko-gradle-plugin/src/main/kotlin/dev/drewhamilton/poko/gradle/PokoPluginExtension.kt
@@ -1,5 +1,7 @@
 package dev.drewhamilton.poko.gradle
 
+import dev.drewhamilton.poko.gradle.ArtifactInfo.DEFAULT_POKO_ANNOTATION
+import dev.drewhamilton.poko.gradle.ArtifactInfo.DEFAULT_POKO_ENABLED
 import javax.inject.Inject
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
@@ -7,7 +9,7 @@ import org.gradle.api.provider.Property
 public abstract class PokoPluginExtension @Inject constructor(objects: ObjectFactory) {
 
     public val enabled: Property<Boolean> = objects.property(Boolean::class.javaObjectType)
-        .convention(true)
+        .convention(DEFAULT_POKO_ENABLED)
 
     /**
      * Define a custom Poko marker annotation. The poko-annotations artifact won't be automatically


### PR DESCRIPTION
Default enabled to true and the annotation to the built-in one.

This is useful for the future 'poko-tests' module where I want to apply the Kotlin compiler plugin solely through the `dependencies { }` and shouldn't need to pass arguments. It also matches the behavior when used through the Gradle plugin.