### PR TITLE
Small IR updates

### DIFF
--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
@@ -13,8 +13,6 @@ import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrProperty
 import org.jetbrains.kotlin.ir.declarations.impl.IrValueParameterImpl
-import org.jetbrains.kotlin.ir.declarations.isMultiFieldValueClass
-import org.jetbrains.kotlin.ir.declarations.isSingleFieldValueClass
 import org.jetbrains.kotlin.ir.symbols.impl.IrValueParameterSymbolImpl
 import org.jetbrains.kotlin.ir.types.createType
 import org.jetbrains.kotlin.ir.util.hasAnnotation
@@ -80,7 +78,7 @@ internal class PokoMembersTransformer(
             messageCollector.reportErrorOnClass(this, "Poko does not support data classes")
             false
         }
-        isSingleFieldValueClass || isMultiFieldValueClass -> {
+        isValue -> {
             messageCollector.log("Value class")
             messageCollector.reportErrorOnClass(this, "Poko does not support value classes")
             false

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/equalsGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/equalsGeneration.kt
@@ -26,7 +26,6 @@ import org.jetbrains.kotlin.ir.builders.irWhen
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrProperty
-import org.jetbrains.kotlin.ir.declarations.isSingleFieldValueClass
 import org.jetbrains.kotlin.ir.expressions.IrBranch
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
@@ -66,10 +65,7 @@ internal fun IrBlockBodyBuilder.generateEqualsMethodBody(
     val irType = irClass.defaultType
     fun irOther(): IrExpression = IrGetValueImpl(functionDeclaration.valueParameters.single())
 
-    if (!irClass.isSingleFieldValueClass) {
-        +irIfThenReturnTrue(irEqeqeq(functionDeclaration.receiver(), irOther()))
-    }
-
+    +irIfThenReturnTrue(irEqeqeq(functionDeclaration.receiver(), irOther()))
     +irIfThenReturnFalse(irNotIs(irOther(), irType))
 
     val otherWithCast = irTemporary(irAs(irOther(), irType), "other_with_cast")


### PR DESCRIPTION
Use built-in isValue property to determine value class. Do not conditionally check for value class when generating equals as they are unsupported.