### PR TITLE
Only test on older JDKs which are commonly LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,8 @@ jobs:
           distribution: zulu
           java-version: |
             8
-            9
-            10
             11
-            12
-            13
-            14
-            15
-            16
             17
-            18
             19
       - name: Build
         uses: gradle/gradle-build-action@v2
@@ -50,7 +42,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        ci_java_version: [ 8, 9, 11, 12, 13, 14, 15, 16, 17, 18, 19 ]
+        ci_java_version: [ 8, 11, 17, 19 ]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3

--- a/poko-compiler-plugin/build.gradle.kts
+++ b/poko-compiler-plugin/build.gradle.kts
@@ -32,7 +32,8 @@ tasks.withType<KotlinCompile>().configureEach {
 }
 
 // https://jakewharton.com/build-on-latest-java-test-through-lowest-java/
-for (javaVersion in 8..18) {
+// The normal test task will run on the latest JDK.
+for (javaVersion in listOf(8, 11, 17)) {
     val jdkTest = tasks.register<Test>("testJdk$javaVersion") {
         val javaToolchains  = project.extensions.getByType<JavaToolchainService>()
         javaLauncher.set(
@@ -48,11 +49,6 @@ for (javaVersion in 8..18) {
         classpath = testTask.classpath
         testClassesDirs = testTask.testClassesDirs
     }
-
-    // JDK 10 is flaky on CI:
-    val isCi = System.getenv()["CI"] == "true"
-    if (isCi && javaVersion == 10)
-        continue
 
     tasks.named("check").configure { dependsOn(jdkTest) }
 }


### PR DESCRIPTION
The OpenJDK itself has no concept of LTS, so any vendor is welcome to deem _any_ version an LTS version, but in general they all follow Oracle's lead with 8, 11, 17, and soon 21. These become a representative sample that covers the overwhelming majority of deployments, and thus should be sufficient for test coverage.

Closes #96