### PR TITLE
Use more features of AssertK

### DIFF
--- a/poko-tests/src/commonTest/kotlin/AnyArrayHolderTest.kt
+++ b/poko-tests/src/commonTest/kotlin/AnyArrayHolderTest.kt
@@ -1,4 +1,5 @@
 
+import assertk.all
 import assertk.assertAll
 import assertk.assertThat
 import assertk.assertions.hashCodeFun
@@ -26,7 +27,6 @@ class AnyArrayHolderTest {
             assertThat(b).isEqualTo(a)
 
             assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
-
             assertThat(a).toStringFun().isEqualTo(b.toString())
         }
     }
@@ -47,7 +47,6 @@ class AnyArrayHolderTest {
             assertThat(b).isEqualTo(a)
 
             assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
-
             assertThat(a).toStringFun().isEqualTo(b.toString())
         }
     }
@@ -68,7 +67,6 @@ class AnyArrayHolderTest {
             assertThat(b).isEqualTo(a)
 
             assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
-
             assertThat(a).toStringFun().isEqualTo(b.toString())
         }
     }
@@ -89,7 +87,6 @@ class AnyArrayHolderTest {
             assertThat(b).isEqualTo(a)
 
             assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
-
             assertThat(a).toStringFun().isEqualTo(b.toString())
         }
     }
@@ -110,7 +107,6 @@ class AnyArrayHolderTest {
             assertThat(b).isEqualTo(a)
 
             assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
-
             assertThat(a).toStringFun().isEqualTo(b.toString())
         }
     }
@@ -131,7 +127,6 @@ class AnyArrayHolderTest {
             assertThat(b).isEqualTo(a)
 
             assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
-
             assertThat(a).toStringFun().isEqualTo(b.toString())
         }
     }
@@ -152,7 +147,6 @@ class AnyArrayHolderTest {
             assertThat(b).isEqualTo(a)
 
             assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
-
             assertThat(a).toStringFun().isEqualTo(b.toString())
         }
     }
@@ -173,7 +167,6 @@ class AnyArrayHolderTest {
             assertThat(b).isEqualTo(a)
 
             assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
-
             assertThat(a).toStringFun().isEqualTo(b.toString())
         }
     }
@@ -194,7 +187,6 @@ class AnyArrayHolderTest {
             assertThat(b).isEqualTo(a)
 
             assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
-
             assertThat(a).toStringFun().isEqualTo(b.toString())
         }
     }
@@ -215,7 +207,6 @@ class AnyArrayHolderTest {
             assertThat(b).isEqualTo(a)
 
             assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
-
             assertThat(a).toStringFun().isEqualTo(b.toString())
         }
     }
@@ -236,7 +227,6 @@ class AnyArrayHolderTest {
             assertThat(b).isEqualTo(a)
 
             assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
-
             assertThat(a).toStringFun().isEqualTo(b.toString())
         }
     }
@@ -297,9 +287,9 @@ class AnyArrayHolderTest {
             nullableAny = arrayOf(1, 2L, 3f, 4.0),
             trailingProperty = "trailing",
         )
-        assertAll {
-            assertThat(poko).hashCodeFun().isEqualTo(data.hashCode())
-            assertThat(poko).toStringFun().isEqualTo(data.toString())
+        assertThat(poko).all {
+            hashCodeFun().isEqualTo(data.hashCode())
+            toStringFun().isEqualTo(data.toString())
         }
     }
 }

--- a/poko-tests/src/commonTest/kotlin/ArrayHolderTest.kt
+++ b/poko-tests/src/commonTest/kotlin/ArrayHolderTest.kt
@@ -1,12 +1,14 @@
-
+import assertk.assertAll
 import assertk.assertThat
+import assertk.assertions.hashCodeFun
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEqualTo
+import assertk.assertions.toStringFun
 import kotlin.test.Test
 import poko.ArrayHolder
 
 class ArrayHolderTest {
-    @Test fun two_equivalent_compiled_ArrayHolder_instances_are_equals() {
+    @Test fun two_equivalent_compiled_ArrayHolder_instances_match() {
         val a = ArrayHolder(
             stringArray = arrayOf("one string", "another string"),
             nullableStringArray = null,
@@ -63,8 +65,13 @@ class ArrayHolderTest {
                 intArrayOf(99, 98, 97),
             ),
         )
-        assertThat(a).isEqualTo(b)
-        assertThat(b).isEqualTo(a)
+        assertAll {
+            assertThat(a).isEqualTo(b)
+            assertThat(b).isEqualTo(a)
+
+            assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
+            assertThat(a).toStringFun().isEqualTo(b.toString())
+        }
     }
 
     @Test fun two_inequivalent_compiled_ArrayHolder_instances_are_not_equals() {
@@ -157,126 +164,5 @@ class ArrayHolderTest {
         )
         assertThat(a).isNotEqualTo(c)
         assertThat(c).isNotEqualTo(a)
-    }
-
-    @Test fun two_equivalent_compiled_ArrayHolder_instances_have_same_hashCode() {
-        val a = ArrayHolder(
-            stringArray = arrayOf("one string", "another string"),
-            nullableStringArray = null,
-            booleanArray = booleanArrayOf(true, false),
-            nullableBooleanArray = null,
-            byteArray = byteArrayOf(1.toByte(), 2.toByte()),
-            nullableByteArray = null,
-            charArray = charArrayOf('a', 'b', 'c', 'c'),
-            nullableCharArray = null,
-            shortArray = shortArrayOf(99.toShort(), 88.toShort()),
-            nullableShortArray = null,
-            intArray = intArrayOf(3, 4, 5),
-            nullableIntArray = null,
-            longArray = longArrayOf(98765L, 43210L),
-            nullableLongArray = null,
-            floatArray = floatArrayOf(3.14f, 1519f),
-            nullableFloatArray = null,
-            doubleArray = doubleArrayOf(2.22222, Double.NaN),
-            nullableDoubleArray = null,
-            nestedStringArray = arrayOf(
-                arrayOf("1A", "2A"),
-                arrayOf("1B", "2B", "3B"),
-            ),
-            nestedIntArray = arrayOf(
-                intArrayOf(1, 2, 3, 4),
-                intArrayOf(99, 98, 97),
-            ),
-        )
-        val b = ArrayHolder(
-            stringArray = arrayOf("one string", "another string"),
-            nullableStringArray = null,
-            booleanArray = booleanArrayOf(true, false),
-            nullableBooleanArray = null,
-            byteArray = byteArrayOf(1.toByte(), 2.toByte()),
-            nullableByteArray = null,
-            charArray = charArrayOf('a', 'b', 'c', 'c'),
-            nullableCharArray = null,
-            shortArray = shortArrayOf(99.toShort(), 88.toShort()),
-            nullableShortArray = null,
-            intArray = intArrayOf(3, 4, 5),
-            nullableIntArray = null,
-            longArray = longArrayOf(98765L, 43210L),
-            nullableLongArray = null,
-            floatArray = floatArrayOf(3.14f, 1519f),
-            nullableFloatArray = null,
-            doubleArray = doubleArrayOf(2.22222, Double.NaN),
-            nullableDoubleArray = null,
-            nestedStringArray = arrayOf(
-                arrayOf("1A", "2A"),
-                arrayOf("1B", "2B", "3B"),
-            ),
-            nestedIntArray = arrayOf(
-                intArrayOf(1, 2, 3, 4),
-                intArrayOf(99, 98, 97),
-            ),
-        )
-
-        assertThat(a.hashCode()).isEqualTo(b.hashCode())
-    }
-
-    @Test fun two_equivalent_compiled_ArrayHolder_instances_have_same_toString() {
-        val a = ArrayHolder(
-            stringArray = arrayOf("one string", "another string"),
-            nullableStringArray = null,
-            booleanArray = booleanArrayOf(true, false),
-            nullableBooleanArray = null,
-            byteArray = byteArrayOf(1.toByte(), 2.toByte()),
-            nullableByteArray = null,
-            charArray = charArrayOf('a', 'b', 'c', 'c'),
-            nullableCharArray = null,
-            shortArray = shortArrayOf(99.toShort(), 88.toShort()),
-            nullableShortArray = null,
-            intArray = intArrayOf(3, 4, 5),
-            nullableIntArray = null,
-            longArray = longArrayOf(98765L, 43210L),
-            nullableLongArray = null,
-            floatArray = floatArrayOf(3.14f, 1519f),
-            nullableFloatArray = null,
-            doubleArray = doubleArrayOf(2.22222, Double.NaN),
-            nullableDoubleArray = null,
-            nestedStringArray = arrayOf(
-                arrayOf("1A", "2A"),
-                arrayOf("1B", "2B", "3B"),
-            ),
-            nestedIntArray = arrayOf(
-                intArrayOf(1, 2, 3, 4),
-                intArrayOf(99, 98, 97),
-            ),
-        )
-        val b = ArrayHolder(
-            stringArray = arrayOf("one string", "another string"),
-            nullableStringArray = null,
-            booleanArray = booleanArrayOf(true, false),
-            nullableBooleanArray = null,
-            byteArray = byteArrayOf(1.toByte(), 2.toByte()),
-            nullableByteArray = null,
-            charArray = charArrayOf('a', 'b', 'c', 'c'),
-            nullableCharArray = null,
-            shortArray = shortArrayOf(99.toShort(), 88.toShort()),
-            nullableShortArray = null,
-            intArray = intArrayOf(3, 4, 5),
-            nullableIntArray = null,
-            longArray = longArrayOf(98765L, 43210L),
-            nullableLongArray = null,
-            floatArray = floatArrayOf(3.14f, 1519f),
-            nullableFloatArray = null,
-            doubleArray = doubleArrayOf(2.22222, Double.NaN),
-            nullableDoubleArray = null,
-            nestedStringArray = arrayOf(
-                arrayOf("1A", "2A"),
-                arrayOf("1B", "2B", "3B"),
-            ),
-            nestedIntArray = arrayOf(
-                intArrayOf(1, 2, 3, 4),
-                intArrayOf(99, 98, 97),
-            ),
-        )
-        assertThat(a.toString()).isEqualTo(b.toString())
     }
 }

--- a/poko-tests/src/commonTest/kotlin/ComplexTest.kt
+++ b/poko-tests/src/commonTest/kotlin/ComplexTest.kt
@@ -1,12 +1,14 @@
+import assertk.assertAll
 import assertk.assertThat
+import assertk.assertions.hashCodeFun
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEqualTo
+import assertk.assertions.toStringFun
 import kotlin.test.Test
-import data.Complex as ComplexData
 import poko.Complex as ComplexPoko
 
 class ComplexTest {
-    @Test fun two_equivalent_compiled_Complex_instances_are_equals() {
+    @Test fun two_equivalent_compiled_Complex_instances_match() {
         val arrayReferenceType = arrayOf("one string", "another string")
         val arrayPrimitiveType = intArrayOf(3, 4, 5)
         val a = ComplexPoko(
@@ -43,8 +45,13 @@ class ComplexTest {
             genericType = EvenInt(2),
             nullableGenericType = null,
         )
-        assertThat(a).isEqualTo(b)
-        assertThat(b).isEqualTo(a)
+        assertAll {
+            assertThat(a).isEqualTo(b)
+            assertThat(b).isEqualTo(a)
+
+            assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
+            assertThat(a).toStringFun().isEqualTo(b.toString())
+        }
     }
 
     @Test fun two_inequivalent_compiled_Complex_instances_are_not_equals() {
@@ -86,86 +93,6 @@ class ComplexTest {
         )
         assertThat(a).isNotEqualTo(b)
         assertThat(b).isNotEqualTo(a)
-    }
-
-    @Test fun compiled_Complex_class_instance_has_expected_hashCode() {
-        val arrayReferenceType = arrayOf("one string", "another string")
-        val arrayPrimitiveType = intArrayOf(3, 4, 5)
-        val poko = ComplexPoko(
-            referenceType = "Text",
-            nullableReferenceType = null,
-            int = 2,
-            nullableInt = null,
-            long = 12345L,
-            float = 67f,
-            double = 89.0,
-            arrayReferenceType = arrayReferenceType,
-            nullableArrayReferenceType = null,
-            arrayPrimitiveType = arrayPrimitiveType,
-            nullableArrayPrimitiveType = null,
-            genericCollectionType = listOf(4, 6, 8).map { EvenInt(it) },
-            nullableGenericCollectionType = null,
-            genericType = EvenInt(2),
-            nullableGenericType = null,
-        )
-        val data = ComplexData(
-            referenceType = "Text",
-            nullableReferenceType = null,
-            int = 2,
-            nullableInt = null,
-            long = 12345L,
-            float = 67f,
-            double = 89.0,
-            arrayReferenceType = arrayReferenceType,
-            nullableArrayReferenceType = null,
-            arrayPrimitiveType = arrayPrimitiveType,
-            nullableArrayPrimitiveType = null,
-            genericCollectionType = listOf(4, 6, 8).map { EvenInt(it) },
-            nullableGenericCollectionType = null,
-            genericType = EvenInt(2),
-            nullableGenericType = null,
-        )
-        assertThat(poko.hashCode()).isEqualTo(data.hashCode())
-    }
-
-    @Test fun compiled_Complex_class_instance_has_expected_toString() {
-        val arrayReferenceType = arrayOf("one string", "another string")
-        val arrayPrimitiveType = intArrayOf(3, 4, 5)
-        val poko = ComplexPoko(
-            referenceType = "Text",
-            nullableReferenceType = null,
-            int = 2,
-            nullableInt = null,
-            long = 12345L,
-            float = 67f,
-            double = 89.0,
-            arrayReferenceType = arrayReferenceType,
-            nullableArrayReferenceType = null,
-            arrayPrimitiveType = arrayPrimitiveType,
-            nullableArrayPrimitiveType = null,
-            genericCollectionType = listOf(4, 6, 8).map { EvenInt(it) },
-            nullableGenericCollectionType = null,
-            genericType = EvenInt(2),
-            nullableGenericType = null,
-        )
-        val data = ComplexData(
-            referenceType = "Text",
-            nullableReferenceType = null,
-            int = 2,
-            nullableInt = null,
-            long = 12345L,
-            float = 67f,
-            double = 89.0,
-            arrayReferenceType = arrayReferenceType,
-            nullableArrayReferenceType = null,
-            arrayPrimitiveType = arrayPrimitiveType,
-            nullableArrayPrimitiveType = null,
-            genericCollectionType = listOf(4, 6, 8).map { EvenInt(it) },
-            nullableGenericCollectionType = null,
-            genericType = EvenInt(2),
-            nullableGenericType = null,
-        )
-        assertThat(poko.toString()).isEqualTo(data.toString())
     }
 
     data class EvenInt(private val value: Int) : Number() {

--- a/poko-tests/src/commonTest/kotlin/ExplicitDeclarationsTest.kt
+++ b/poko-tests/src/commonTest/kotlin/ExplicitDeclarationsTest.kt
@@ -1,6 +1,9 @@
+import assertk.all
 import assertk.assertThat
+import assertk.assertions.hashCodeFun
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEqualTo
+import assertk.assertions.toStringFun
 import kotlin.test.Test
 import data.ExplicitDeclarations as ExplicitDeclarationsData
 import poko.ExplicitDeclarations as ExplicitDeclarationsPoko
@@ -21,18 +24,19 @@ class ExplicitDeclarationsTest {
     }
 
     @Test fun compilation_with_explicit_function_declarations_respects_explicit_hashCode() {
-        val testString = "test thing"
-        val poko = ExplicitDeclarationsPoko(testString)
-        val data = ExplicitDeclarationsData(testString)
-        assertThat(poko.hashCode()).isEqualTo(testString.length)
-        assertThat(poko.hashCode()).isEqualTo(data.hashCode())
-    }
-
-    @Test fun compilation_with_explicit_function_declarations_respects_explicit_toString() {
         val testString = "test string"
         val poko = ExplicitDeclarationsPoko(testString)
         val data = ExplicitDeclarationsData(testString)
-        assertThat(poko.toString()).isEqualTo(testString)
-        assertThat(poko.toString()).isEqualTo(data.toString())
+
+        assertThat(poko).all {
+            hashCodeFun().all {
+                isEqualTo(testString.length)
+                isEqualTo(data.hashCode())
+            }
+            toStringFun().all {
+                isEqualTo(testString)
+                isEqualTo(data.toString())
+            }
+        }
     }
 }

--- a/poko-tests/src/commonTest/kotlin/GenericArrayHolderTest.kt
+++ b/poko-tests/src/commonTest/kotlin/GenericArrayHolderTest.kt
@@ -1,7 +1,8 @@
-
 import assertk.assertThat
+import assertk.assertions.hashCodeFun
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEqualTo
+import assertk.assertions.toStringFun
 import kotlin.test.Test
 import poko.GenericArrayHolder
 
@@ -11,18 +12,8 @@ class GenericArrayHolderTest {
         val b = GenericArrayHolder(arrayOf(arrayOf("5%, 10%"), intArrayOf(5, 10), booleanArrayOf(false, true)))
         assertThat(a).isEqualTo(b)
         assertThat(b).isEqualTo(a)
-    }
-
-    @Test fun two_GenericArrayHolder_instances_with_equivalent_typed_arrays_have_same_hashCode() {
-        val a = GenericArrayHolder(arrayOf(arrayOf("5%, 10%"), intArrayOf(5, 10), booleanArrayOf(false, true)))
-        val b = GenericArrayHolder(arrayOf(arrayOf("5%, 10%"), intArrayOf(5, 10), booleanArrayOf(false, true)))
-        assertThat(a.hashCode()).isEqualTo(b.hashCode())
-    }
-
-    @Test fun two_GenericArrayHolder_instances_with_equivalent_typed_arrays_have_same_toString() {
-        val a = GenericArrayHolder(arrayOf(arrayOf("5%, 10%"), intArrayOf(5, 10), booleanArrayOf(false, true)))
-        val b = GenericArrayHolder(arrayOf(arrayOf("5%, 10%"), intArrayOf(5, 10), booleanArrayOf(false, true)))
-        assertThat(a.toString()).isEqualTo(b.toString())
+        assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
+        assertThat(a).toStringFun().isEqualTo(b.toString())
     }
 
     @Test fun two_GenericArrayHolder_instances_with_equivalent_int_arrays_are_equals() {
@@ -30,18 +21,8 @@ class GenericArrayHolderTest {
         val b = GenericArrayHolder(intArrayOf(5, 10))
         assertThat(a).isEqualTo(b)
         assertThat(b).isEqualTo(a)
-    }
-
-    @Test fun two_GenericArrayHolder_instances_with_equivalent_int_arrays_have_same_hashCode() {
-        val a = GenericArrayHolder(intArrayOf(5, 10))
-        val b = GenericArrayHolder(intArrayOf(5, 10))
-        assertThat(a.hashCode()).isEqualTo(b.hashCode())
-    }
-
-    @Test fun two_GenericArrayHolder_instances_with_equivalent_int_arrays_have_same_toString() {
-        val a = GenericArrayHolder(intArrayOf(5, 10))
-        val b = GenericArrayHolder(intArrayOf(5, 10))
-        assertThat(a.toString()).isEqualTo(b.toString())
+        assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
+        assertThat(a).toStringFun().isEqualTo(b.toString())
     }
 
     @Test fun two_GenericArrayHolder_instances_with_equivalent_nonarrays_are_equals() {
@@ -49,18 +30,8 @@ class GenericArrayHolderTest {
         val b = GenericArrayHolder("5, 10")
         assertThat(a).isEqualTo(b)
         assertThat(b).isEqualTo(a)
-    }
-
-    @Test fun two_GenericArrayHolder_instances_with_equivalent_nonarrays_have_same_hashCode() {
-        val a = GenericArrayHolder("5, 10")
-        val b = GenericArrayHolder("5, 10")
-        assertThat(a.hashCode()).isEqualTo(b.hashCode())
-    }
-
-    @Test fun two_GenericArrayHolder_instances_with_equivalent_nonarrays_have_same_toString() {
-        val a = GenericArrayHolder("5, 10")
-        val b = GenericArrayHolder("5, 10")
-        assertThat(a.toString()).isEqualTo(b.toString())
+        assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
+        assertThat(a).toStringFun().isEqualTo(b.toString())
     }
 
     @Test fun two_GenericArrayHolder_instances_holding_inequivalent_long_arrays_are_not_equals() {

--- a/poko-tests/src/commonTest/kotlin/NestedTest.kt
+++ b/poko-tests/src/commonTest/kotlin/NestedTest.kt
@@ -1,6 +1,9 @@
+import assertk.all
 import assertk.assertThat
+import assertk.assertions.hashCodeFun
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEqualTo
+import assertk.assertions.toStringFun
 import kotlin.test.Test
 import data.OuterClass.Nested as NestedData
 import poko.OuterClass.Nested as NestedPoko
@@ -23,12 +26,9 @@ class NestedTest {
     @Test fun compilation_of_nested_class_within_class_matches_corresponding_data_class_hashCode() {
         val poko = NestedPoko("nested class value")
         val data = NestedData("nested class value")
-        assertThat(poko.hashCode()).isEqualTo(data.hashCode())
-    }
-
-    @Test fun compilation_of_nested_class_within_class_matches_corresponding_data_class_toString() {
-        val poko = NestedPoko("nested class value")
-        val data = NestedData("nested class value")
-        assertThat(poko.toString()).isEqualTo(data.toString())
+        assertThat(poko).all {
+            hashCodeFun().isEqualTo(data.hashCode())
+            toStringFun().isEqualTo(data.toString())
+        }
     }
 }

--- a/poko-tests/src/commonTest/kotlin/SimpleTest.kt
+++ b/poko-tests/src/commonTest/kotlin/SimpleTest.kt
@@ -1,6 +1,9 @@
+import assertk.all
 import assertk.assertThat
+import assertk.assertions.hashCodeFun
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEqualTo
+import assertk.assertions.toStringFun
 import kotlin.test.Test
 import data.Simple as SimpleData
 import poko.Simple as SimplePoko
@@ -23,12 +26,9 @@ class SimpleTest {
     @Test fun compiled_Simple_class_instance_has_expected_hashCode() {
         val poko = SimplePoko(1, "String", null)
         val data = SimpleData(1, "String", null)
-        assertThat(poko.hashCode()).isEqualTo(data.hashCode())
-    }
-
-    @Test fun compiled_Simple_class_instance_has_expected_toString() {
-        val poko = SimplePoko(1, "String", null)
-        val data = SimpleData(1, "String", null)
-        assertThat(poko.toString()).isEqualTo(data.toString())
+        assertThat(poko).all {
+            hashCodeFun().isEqualTo(data.hashCode())
+            toStringFun().isEqualTo(data.toString())
+        }
     }
 }

--- a/poko-tests/src/commonTest/kotlin/SimpleWithExtraParamTest.kt
+++ b/poko-tests/src/commonTest/kotlin/SimpleWithExtraParamTest.kt
@@ -1,5 +1,7 @@
 import assertk.assertThat
+import assertk.assertions.hashCodeFun
 import assertk.assertions.isEqualTo
+import assertk.assertions.toStringFun
 import kotlin.test.Test
 import poko.SimpleWithExtraParam
 
@@ -9,17 +11,7 @@ class SimpleWithExtraParamTest {
         val b = SimpleWithExtraParam(1, "String", null, { false })
         assertThat(a).isEqualTo(b)
         assertThat(b).isEqualTo(a)
-    }
-
-    @Test fun nonproperty_parameter_is_ignored_for_hashCode() {
-        val a = SimpleWithExtraParam(1, "String", null, { true })
-        val b = SimpleWithExtraParam(1, "String", null, { false })
-        assertThat(a.hashCode()).isEqualTo(b.hashCode())
-    }
-
-    @Test fun nonproperty_parameter_is_ignored_for_toString() {
-        val a = SimpleWithExtraParam(1, "String", null, { true })
-        val b = SimpleWithExtraParam(1, "String", null, { false })
-        assertThat(a.toString()).isEqualTo(b.toString())
+        assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
+        assertThat(a).toStringFun().isEqualTo(b.toString())
     }
 }

--- a/poko-tests/src/commonTest/kotlin/SuperclassDeclarationsTest.kt
+++ b/poko-tests/src/commonTest/kotlin/SuperclassDeclarationsTest.kt
@@ -1,6 +1,9 @@
+import assertk.all
 import assertk.assertThat
+import assertk.assertions.hashCodeFun
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEqualTo
+import assertk.assertions.toStringFun
 import kotlin.test.Test
 import data.SuperclassDeclarations as SuperclassDeclarationsData
 import poko.SuperclassDeclarations as SuperclassDeclarationsPoko
@@ -32,14 +35,15 @@ class SuperclassDeclarationsTest {
     @Test fun superclass_hashCode_is_overridden() {
         val poko = SuperclassDeclarationsPoko(123.4)
         val data = SuperclassDeclarationsData(123.4)
-        assertThat(poko.hashCode()).isEqualTo(data.hashCode())
-        assertThat(poko.hashCode()).isNotEqualTo(50934)
-    }
-
-    @Test fun superclass_toString_is_overridden() {
-        val poko = SuperclassDeclarationsPoko(123.4)
-        val data = SuperclassDeclarationsData(123.4)
-        assertThat(poko.toString()).isEqualTo(data.toString())
-        assertThat(poko.toString()).isNotEqualTo("superclass")
+        assertThat(poko).all {
+            hashCodeFun().all {
+                isEqualTo(data.hashCode())
+                isNotEqualTo(50934)
+            }
+            toStringFun().all {
+                isEqualTo(data.toString())
+                isNotEqualTo("superclass")
+            }
+        }
     }
 }


### PR DESCRIPTION
Still more we could do here, like add a `isSymmetricallyEqualTo()` helper to eliminate the double a equals b/b equals a checks.