### PR TITLE
Migrate `ComplexGenericArrayHolder` test

### DIFF
--- a/poko-tests/src/commonMain/kotlin/poko/ComplexGenericArrayHolder.kt
+++ b/poko-tests/src/commonMain/kotlin/poko/ComplexGenericArrayHolder.kt
@@ -1,4 +1,4 @@
-package api
+package poko
 
 import dev.drewhamilton.poko.ArrayContentBased
 import dev.drewhamilton.poko.ArrayContentSupport

--- a/poko-tests/src/commonTest/kotlin/ComplexGenericArrayHolderTest.kt
+++ b/poko-tests/src/commonTest/kotlin/ComplexGenericArrayHolderTest.kt
@@ -1,0 +1,17 @@
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import poko.ComplexGenericArrayHolder
+
+class ComplexGenericArrayHolderTest {
+    @Test fun two_ComplexGenericArrayHolder_instances_with_equivalent_int_arrays_are_equals() {
+        val a = ComplexGenericArrayHolder(
+            generic = intArrayOf(50, 100),
+        )
+        val b = ComplexGenericArrayHolder(
+            generic = intArrayOf(50, 100),
+        )
+        assertThat(a).isEqualTo(b)
+        assertThat(b).isEqualTo(a)
+    }
+}


### PR DESCRIPTION
Accidentally dropped this when migrating `AnyArrayHolder`.

Closes #180 