### PR TITLE
Integer fast-path for `hashCode` calculation

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotl
 kotlin-gradleApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }
 
 assertk = "com.willowtreeapps.assertk:assertk:0.26.1"
+asm-util = "org.ow2.asm:asm-util:9.5"
 
 [plugins]
 

--- a/poko-compiler-plugin/build.gradle.kts
+++ b/poko-compiler-plugin/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     testImplementation(libs.kotlin.compileTesting)
     testImplementation(libs.junit)
     testImplementation(libs.assertk)
+    testImplementation(libs.asm.util)
 }
 
 tasks.withType<KotlinCompile>().configureEach {

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
@@ -31,6 +31,7 @@ import org.jetbrains.kotlin.ir.symbols.IrTypeParameterSymbol
 import org.jetbrains.kotlin.ir.symbols.impl.IrVariableSymbolImpl
 import org.jetbrains.kotlin.ir.types.classifierOrFail
 import org.jetbrains.kotlin.ir.types.classifierOrNull
+import org.jetbrains.kotlin.ir.types.isInt
 import org.jetbrains.kotlin.ir.types.isNullable
 import org.jetbrains.kotlin.ir.util.functions
 import org.jetbrains.kotlin.ir.util.render
@@ -139,6 +140,11 @@ private fun IrBlockBodyBuilder.getHashCodeOf(
     value: IrExpression,
     messageCollector: MessageCollector,
 ): IrExpression {
+    // Fast path for integers which are already their own hashCode value.
+    if (property.type.isInt()) {
+        return value
+    }
+
     val hasArrayContentBasedAnnotation = property.hasArrayContentBasedAnnotation()
     val classifier = property.type.classifierOrNull
 

--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
@@ -1,7 +1,9 @@
 package dev.drewhamilton.poko
 
+import assertk.all
 import assertk.assertThat
 import assertk.assertions.contains
+import assertk.assertions.doesNotContain
 import assertk.assertions.isEqualTo
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.PluginOption
@@ -119,6 +121,21 @@ class PokoCompilerPluginTest {
             expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
         ) {
             assertThat(it.messages).isEqualTo("e: Could not find class <nonexistent/ClassName>\n")
+        }
+    }
+    //endregion
+
+    //region Performance optimizations
+    @Test fun `int property does not emit hashCode method invocation`() {
+        testCompilation(
+            "api/Primitives",
+        ) {
+            val classFile = it.generatedFiles.single { it.name.endsWith(".class") }
+            val bytecode = bytecodeToText(classFile.readBytes())
+            assertThat(bytecode).all {
+                contains("java/lang/Long.hashCode")
+                doesNotContain("java/lang/Integer.hashCode")
+            }
         }
     }
     //endregion

--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/asm.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/asm.kt
@@ -1,0 +1,16 @@
+package dev.drewhamilton.poko
+
+import java.io.PrintWriter
+import java.io.StringWriter
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.util.Textifier
+import org.objectweb.asm.util.TraceClassVisitor
+
+fun bytecodeToText(bytecode: ByteArray): String {
+    val textifier = Textifier()
+    ClassReader(bytecode).accept(TraceClassVisitor(null, textifier, null), 0)
+
+    val writer = StringWriter()
+    textifier.print(PrintWriter(writer))
+    return writer.toString().trim()
+}


### PR DESCRIPTION
An integer is its own `hashCode`, and the function is documented to simply return the input on the JVM. For JS and native the behavior is the same: https://github.com/JetBrains/kotlin/blob/1.9.0/kotlin-native/runtime/src/main/kotlin/kotlin/Primitives.kt#L1353.

Saves at least 3 bytes per property within the function bytecode, not counting any effects on things like the constant pool (for JVM).

Before:

    public int hashCode();
      Code:
         0: aload_0
         1: getfield      #23                 // Field int:I
         4: invokestatic  #50                 // Method java/lang/Integer.hashCode:(I)I
         7: istore_1
         8: iload_1
         9: bipush        31
        11: imul
         ⋮
        46: ireturn

After:

    public int hashCode();
      Code:
         0: aload_0
         1: getfield      #23                 // Field int:I
         4: istore_1
         5: iload_1
         6: bipush        31
         8: imul
         ⋮
        43: ireturn

Future work (will add to issue):
- Support `UInt` by emitting a call to `toInt()` which should basically be a no-op (and eliminated completely on the JVM at least).
- Eliminate wasteful store/load instructions between operations.

Refs #204