### PR TITLE
Vary the integration test JDK toolchains

### DIFF
--- a/poko-compiler-plugin/build.gradle.kts
+++ b/poko-compiler-plugin/build.gradle.kts
@@ -30,25 +30,3 @@ tasks.withType<KotlinCompile>().configureEach {
         freeCompilerArgs.add("-Xcontext-receivers")
     }
 }
-
-// https://jakewharton.com/build-on-latest-java-test-through-lowest-java/
-// The normal test task will run on the latest JDK.
-for (javaVersion in listOf(8, 11, 17)) {
-    val jdkTest = tasks.register<Test>("testJdk$javaVersion") {
-        val javaToolchains  = project.extensions.getByType<JavaToolchainService>()
-        javaLauncher.set(
-            javaToolchains.launcherFor {
-                languageVersion.set(JavaLanguageVersion.of(javaVersion))
-            }
-        )
-
-        description = "Runs the test suite on JDK $javaVersion"
-        group = LifecycleBasePlugin.VERIFICATION_GROUP
-
-        val testTask = tasks.getByName("test") as Test
-        classpath = testTask.classpath
-        testClassesDirs = testTask.testClassesDirs
-    }
-
-    tasks.named("check").configure { dependsOn(jdkTest) }
-}

--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
@@ -7,7 +7,6 @@ import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.PluginOption
 import com.tschuchort.compiletesting.SourceFile
 import java.io.File
-import org.jetbrains.kotlin.backend.common.extensions.FirIncompatiblePluginAPI
 import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfigurationKey
@@ -167,7 +166,6 @@ class PokoCompilerPluginTest {
         additionalTesting(result)
     }
 
-    @OptIn(FirIncompatiblePluginAPI::class)
     private fun prepareCompilation(
         vararg sourceFiles: SourceFile,
         pokoAnnotationName: String,
@@ -177,7 +175,7 @@ class PokoCompilerPluginTest {
         inheritClassPath = true
         sources = sourceFiles.asList()
         verbose = false
-        jvmTarget = compilerJvmTarget.description
+        jvmTarget = JvmTarget.JVM_1_8.description
         useIR = true
 
         val commandLineProcessor = PokoCommandLineProcessor()
@@ -197,30 +195,4 @@ class PokoCompilerPluginTest {
     private fun SourceFile.Companion.fromPath(path: String): SourceFile = fromPath(File(path))
     //endregion
 
-    companion object {
-
-        private val compilerJvmTarget: JvmTarget by lazy {
-            val resolvedJvmDescription = getJavaRuntimeVersion()
-            val resolvedJvmTarget = JvmTarget.fromString(resolvedJvmDescription)
-            val default = JvmTarget.JVM_1_8
-
-            val message = if (resolvedJvmTarget == null) {
-                "${default.description} because test runtime JVM version <$resolvedJvmDescription> was not valid"
-            } else {
-                "${resolvedJvmTarget.description} determined from test runtime JVM"
-            }
-            println("${PokoCompilerPluginTest::class.java.simpleName}: Using jvmTarget $message")
-
-            resolvedJvmTarget ?: default
-        }
-
-        private fun getJavaRuntimeVersion(): String {
-            val runtimeVersionArray = System.getProperty("java.runtime.version").split(".", "_", "-b")
-            val prefix = runtimeVersionArray[0]
-            return if (prefix == "1")
-                "1.${runtimeVersionArray[1]}"
-            else
-                prefix
-        }
-    }
 }

--- a/poko-tests/build.gradle.kts
+++ b/poko-tests/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.NATIVE_COMPILER_PLUGIN_CLASSPATH_CONFIGURATION_NAME
 import org.jetbrains.kotlin.gradle.plugin.PLUGIN_CLASSPATH_CONFIGURATION_NAME
 
@@ -5,8 +6,23 @@ plugins {
   alias(libs.plugins.kotlin.multiplatform)
 }
 
+fun KotlinMultiplatformExtension.jvm(version: Int) {
+  jvm("jvm$version") {
+    compilations.configureEach {
+      jvmToolchain(version)
+    }
+
+    // Dummy value required to disambiguate these targets' configurations.
+    // See https://kotlinlang.org/docs/multiplatform-set-up-targets.html#distinguish-several-targets-for-one-platform
+    attributes.attribute(Attribute.of("com.example.JvmTarget", Int::class.javaObjectType), version)
+  }
+}
+
 kotlin {
-  jvm()
+  jvm(8)
+  jvm(11)
+  jvm(17)
+  jvm() // Build JDK which should be latest.
 
   js().nodejs()
 


### PR DESCRIPTION
Now that the majority of the tests have migrated from the compiler module to a dedicated integration test module the JDK test variance needs to move as well. Thankfully, Kotlin makes this relatively simple.