### PR TITLE
Support K2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ kotlin-gradleApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", v
 
 assertk = "com.willowtreeapps.assertk:assertk:0.26.1"
 asm-util = "org.ow2.asm:asm-util:9.5"
+testParameterInjector = "com.google.testparameterinjector:test-parameter-injector:1.12"
 
 [plugins]
 

--- a/poko-compiler-plugin/build.gradle.kts
+++ b/poko-compiler-plugin/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.assertk)
     testImplementation(libs.asm.util)
+    testImplementation(libs.testParameterInjector)
 }
 
 tasks.withType<KotlinCompile>().configureEach {

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCompilerPluginRegistrar.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCompilerPluginRegistrar.kt
@@ -16,8 +16,7 @@ import org.jetbrains.kotlin.name.ClassId
 @AutoService(CompilerPluginRegistrar::class)
 public class PokoCompilerPluginRegistrar : CompilerPluginRegistrar() {
 
-    // TODO: Support K2
-    override val supportsK2: Boolean = false
+    override val supportsK2: Boolean = true
 
     override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
         if (!configuration.get(CompilerOptions.ENABLED, DEFAULT_POKO_ENABLED))

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCompilerPluginRegistrar.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCompilerPluginRegistrar.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.name.ClassId
 @AutoService(CompilerPluginRegistrar::class)
 public class PokoCompilerPluginRegistrar : CompilerPluginRegistrar() {
 
-    override val supportsK2: Boolean = true
+    override val supportsK2: Boolean get() = true
 
     override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
         if (!configuration.get(CompilerOptions.ENABLED, DEFAULT_POKO_ENABLED))

--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
@@ -125,7 +125,7 @@ class PokoCompilerPluginTest(
             pokoAnnotationName = "nonexistent/ClassName",
             expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
         ) {
-            assertThat(it.messages).isEqualTo("e: Could not find class <nonexistent/ClassName>\n")
+            assertThat(it.messages).contains("e: Could not find class <nonexistent/ClassName>\n")
         }
     }
     //endregion

--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
@@ -5,6 +5,8 @@ import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.doesNotContain
 import assertk.assertions.isEqualTo
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.PluginOption
 import com.tschuchort.compiletesting.SourceFile
@@ -17,9 +19,13 @@ import org.junit.Assert.fail
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
 
 @OptIn(ExperimentalCompilerApi::class)
-class PokoCompilerPluginTest {
+@RunWith(TestParameterInjector::class)
+class PokoCompilerPluginTest(
+    @TestParameter private val k2: Boolean,
+) {
 
     @JvmField
     @Rule var temporaryFolder: TemporaryFolder = TemporaryFolder()
@@ -141,7 +147,7 @@ class PokoCompilerPluginTest {
 
     private inline fun testCompilation(
         vararg sourceFileNames: String,
-        pokoAnnotationName: String = Poko::class.java.name,
+        pokoAnnotationName: String = "dev/drewhamilton/poko/Poko",
         expectedExitCode: KotlinCompilation.ExitCode = KotlinCompilation.ExitCode.OK,
         additionalTesting: (KotlinCompilation.Result) -> Unit = {}
     ) = testCompilation(
@@ -194,6 +200,9 @@ class PokoCompilerPluginTest {
         verbose = false
         jvmTarget = JvmTarget.JVM_1_8.description
         useIR = true
+        if (k2) {
+            languageVersion = "2.0"
+        }
 
         val commandLineProcessor = PokoCommandLineProcessor()
         commandLineProcessors = listOf(commandLineProcessor)

--- a/poko-compiler-plugin/src/test/resources/illegal/NoConstructorProperties.kt
+++ b/poko-compiler-plugin/src/test/resources/illegal/NoConstructorProperties.kt
@@ -2,7 +2,9 @@ package illegal
 
 import dev.drewhamilton.poko.Poko
 
-@Suppress("unused")
+@Suppress("unused", "UNUSED_PARAMETER")
 @Poko class NoConstructorProperties(
-    @Suppress("UNUSED_PARAMETER") nonProperty: String,
-)
+    nonProperty: String,
+) {
+    val nonParameter: String = ""
+}

--- a/poko-tests/build.gradle.kts
+++ b/poko-tests/build.gradle.kts
@@ -1,13 +1,19 @@
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 import org.jetbrains.kotlin.gradle.plugin.NATIVE_COMPILER_PLUGIN_CLASSPATH_CONFIGURATION_NAME
 import org.jetbrains.kotlin.gradle.plugin.PLUGIN_CLASSPATH_CONFIGURATION_NAME
+import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
 
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
 }
 
-fun KotlinMultiplatformExtension.jvm(version: Int) {
-  jvm("jvm$version") {
+fun KotlinMultiplatformExtension.jvm(
+  version: Int,
+  baseName: String = "jvm",
+): KotlinJvmTarget {
+  return jvm(baseName.replace("jvm", "jvm$version")) {
     compilations.configureEach {
       jvmToolchain(version)
     }
@@ -18,35 +24,69 @@ fun KotlinMultiplatformExtension.jvm(version: Int) {
   }
 }
 
+fun <T : KotlinTarget> T.applyK2(): T {
+  compilations.configureEach {
+    compilerOptions.options.languageVersion.set(KotlinVersion.KOTLIN_2_0)
+  }
+
+  // Dummy value required to disambiguate these targets' configurations.
+  // See https://kotlinlang.org/docs/multiplatform-set-up-targets.html#distinguish-several-targets-for-one-platform
+  attributes.attribute(Attribute.of("com.example.useK2", Boolean::class.javaObjectType), true)
+
+  return this
+}
+
 kotlin {
   jvm(8)
+  jvm(8, "jvmK2").applyK2()
   jvm(11)
+  jvm(11, "jvmK2").applyK2()
   jvm(17)
-  jvm() // Build JDK which should be latest.
+  jvm(17, "jvmK2").applyK2()
+  // Build JDK which should be latest:
+  jvm()
+  jvm("jvmK2").applyK2()
 
   js().nodejs()
+  js("jsK2").applyK2().nodejs()
 
   mingwX64()
+  mingwX64("mingwX64K2").applyK2()
 
   linuxArm64()
+  linuxArm64("linuxArm64K2").applyK2()
   linuxX64()
+  linuxX64("linuxX64K2").applyK2()
 
   iosArm64()
+  iosArm64("iosArm64K2").applyK2()
   iosSimulatorArm64()
+  iosSimulatorArm64("iosSimulatorArm64K2").applyK2()
   iosX64()
+  iosX64("iosX64K2").applyK2()
 
   macosArm64()
+  macosArm64("macosArm64K2").applyK2()
   macosX64()
+  macosX64("macosX64K2").applyK2()
 
   tvosArm64()
+  tvosArm64("tvosArm64K2").applyK2()
   tvosX64()
+  tvosX64("tvosX64K2").applyK2()
   tvosSimulatorArm64()
+  tvosSimulatorArm64("tvosSimulatorArm64K2").applyK2()
 
   watchosArm32()
+  watchosArm32("watchosArm32K2").applyK2()
   watchosArm64()
+  watchosArm64("watchosArm64K2").applyK2()
   watchosDeviceArm64()
+  watchosDeviceArm64("watchosDeviceArm64K2").applyK2()
   watchosSimulatorArm64()
+  watchosSimulatorArm64("watchosSimulatorArm64K2").applyK2()
   watchosX64()
+  watchosX64("watchosX64K2").applyK2()
 
   sourceSets {
     commonMain {

--- a/poko-tests/src/commonTest/kotlin/GenericArrayHolderTest.kt
+++ b/poko-tests/src/commonTest/kotlin/GenericArrayHolderTest.kt
@@ -7,9 +7,10 @@ import kotlin.test.Test
 import poko.GenericArrayHolder
 
 class GenericArrayHolderTest {
+    @Suppress("RemoveExplicitTypeArguments") // https://youtrack.jetbrains.com/issue/KT-61627
     @Test fun two_GenericArrayHolder_instances_with_equivalent_typed_arrays_are_equals() {
-        val a = GenericArrayHolder(arrayOf(arrayOf("5%, 10%"), intArrayOf(5, 10), booleanArrayOf(false, true)))
-        val b = GenericArrayHolder(arrayOf(arrayOf("5%, 10%"), intArrayOf(5, 10), booleanArrayOf(false, true)))
+        val a = GenericArrayHolder(arrayOf<Any>(arrayOf("5%, 10%"), intArrayOf(5, 10), booleanArrayOf(false, true)))
+        val b = GenericArrayHolder(arrayOf<Any>(arrayOf("5%, 10%"), intArrayOf(5, 10), booleanArrayOf(false, true)))
         assertThat(a).isEqualTo(b)
         assertThat(b).isEqualTo(a)
         assertThat(a).hashCodeFun().isEqualTo(b.hashCode())


### PR DESCRIPTION
Closes #118. Poko now works for Kotlin language version 2.0 (and continues to work for 1.9).