### PR TITLE
Migrate performance tests to occur on tests project

### DIFF
--- a/poko-compiler-plugin/build.gradle.kts
+++ b/poko-compiler-plugin/build.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
     testImplementation(libs.kotlin.compileTesting)
     testImplementation(libs.junit)
     testImplementation(libs.assertk)
-    testImplementation(libs.asm.util)
     testImplementation(libs.testParameterInjector)
 }
 

--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
@@ -130,21 +130,6 @@ class PokoCompilerPluginTest(
     }
     //endregion
 
-    //region Performance optimizations
-    @Test fun `int property does not emit hashCode method invocation`() {
-        testCompilation(
-            "api/Primitives",
-        ) {
-            val classFile = it.generatedFiles.single { it.name.endsWith(".class") }
-            val bytecode = bytecodeToText(classFile.readBytes())
-            assertThat(bytecode).all {
-                contains("java/lang/Long.hashCode")
-                doesNotContain("java/lang/Integer.hashCode")
-            }
-        }
-    }
-    //endregion
-
     private inline fun testCompilation(
         vararg sourceFileNames: String,
         pokoAnnotationName: String = "dev/drewhamilton/poko/Poko",

--- a/poko-tests/performance/build.gradle.kts
+++ b/poko-tests/performance/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+}
+
+dependencies {
+    testImplementation(libs.junit)
+    testImplementation(libs.assertk)
+    testImplementation(libs.asm.util)
+}
+
+tasks.named("test") {
+    dependsOn(":poko-tests:compileKotlinJvm")
+}

--- a/poko-tests/performance/src/test/kotlin/JvmPerformanceTest.kt
+++ b/poko-tests/performance/src/test/kotlin/JvmPerformanceTest.kt
@@ -1,0 +1,16 @@
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.doesNotContain
+import org.junit.Test
+
+class JvmPerformanceTest {
+    @Test fun `int property does not emit hashCode method invocation`() {
+        val classfile = jvmOutput("performance/IntAndLong.class")
+        val bytecode = bytecodeToText(classfile.readBytes())
+        assertThat(bytecode).all {
+            contains("java/lang/Long.hashCode")
+            doesNotContain("java/lang/Integer.hashCode")
+        }
+    }
+}

--- a/poko-tests/performance/src/test/kotlin/asm.kt
+++ b/poko-tests/performance/src/test/kotlin/asm.kt
@@ -1,5 +1,3 @@
-package dev.drewhamilton.poko
-
 import java.io.PrintWriter
 import java.io.StringWriter
 import org.objectweb.asm.ClassReader

--- a/poko-tests/performance/src/test/kotlin/sources.kt
+++ b/poko-tests/performance/src/test/kotlin/sources.kt
@@ -1,0 +1,3 @@
+import java.io.File
+
+fun jvmOutput(relativePath: String) = File("../build/classes/kotlin/jvm/main", relativePath)

--- a/poko-tests/src/commonMain/kotlin/performance/IntAndLong.kt
+++ b/poko-tests/src/commonMain/kotlin/performance/IntAndLong.kt
@@ -1,0 +1,9 @@
+package performance
+
+import dev.drewhamilton.poko.Poko
+
+@Suppress("unused")
+@Poko class IntAndLong(
+    val int: Int,
+    val long: Long,
+)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,4 +20,5 @@ include(
     ":poko-annotations",
     ":poko-gradle-plugin",
     ":poko-tests",
+    ":poko-tests:performance",
 )


### PR DESCRIPTION
This will open up the ability to assert on JS and native which simply isn't possible with the Kotlin Compiler Testing infrastructure.