### PR TITLE
Eliminate redundant instanceof check in JS output

### DIFF
--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/equalsGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/equalsGeneration.kt
@@ -7,7 +7,6 @@ import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.ir.builders.IrBlockBodyBuilder
 import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
 import org.jetbrains.kotlin.ir.builders.IrGeneratorContextInterface
-import org.jetbrains.kotlin.ir.builders.irAs
 import org.jetbrains.kotlin.ir.builders.irBranch
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irElseBranch
@@ -19,6 +18,7 @@ import org.jetbrains.kotlin.ir.builders.irGetField
 import org.jetbrains.kotlin.ir.builders.irIfThenElse
 import org.jetbrains.kotlin.ir.builders.irIfThenReturnFalse
 import org.jetbrains.kotlin.ir.builders.irIfThenReturnTrue
+import org.jetbrains.kotlin.ir.builders.irImplicitCast
 import org.jetbrains.kotlin.ir.builders.irIs
 import org.jetbrains.kotlin.ir.builders.irNotEquals
 import org.jetbrains.kotlin.ir.builders.irNotIs
@@ -70,7 +70,7 @@ internal fun IrBlockBodyBuilder.generateEqualsMethodBody(
     +irIfThenReturnTrue(irEqeqeq(functionDeclaration.receiver(), irOther()))
     +irIfThenReturnFalse(irNotIs(irOther(), irType))
 
-    val otherWithCast = irTemporary(irAs(irOther(), irType), "other_with_cast")
+    val otherWithCast = irTemporary(irImplicitCast(irOther(), irType), "other_with_cast")
     for (property in classProperties) {
         val field = property.backingField!!
         val arg1 = irGetField(functionDeclaration.receiver(), field)

--- a/poko-tests/build.gradle.kts
+++ b/poko-tests/build.gradle.kts
@@ -47,7 +47,11 @@ kotlin {
   jvm()
   jvm("jvmK2").applyK2()
 
-  js().nodejs()
+  js {
+    nodejs()
+    // Produce a JS file for performance tests.
+    binaries.executable()
+  }
   js("jsK2").applyK2().nodejs()
 
   mingwX64()

--- a/poko-tests/performance/build.gradle.kts
+++ b/poko-tests/performance/build.gradle.kts
@@ -9,5 +9,6 @@ dependencies {
 }
 
 tasks.named("test") {
+    dependsOn(":poko-tests:compileProductionExecutableKotlinJs")
     dependsOn(":poko-tests:compileKotlinJvm")
 }

--- a/poko-tests/performance/src/test/kotlin/JsPerformanceTest.kt
+++ b/poko-tests/performance/src/test/kotlin/JsPerformanceTest.kt
@@ -1,0 +1,15 @@
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.doesNotContain
+import org.junit.Test
+
+class JsPerformanceTest {
+    @Test fun `equals does not perform redundant instanceof check`() {
+        val javascript = jsOutput().readText()
+        assertThat(javascript).all {
+            contains("other instanceof IntAndLong")
+            doesNotContain("THROW_CCE")
+        }
+    }
+}

--- a/poko-tests/performance/src/test/kotlin/sources.kt
+++ b/poko-tests/performance/src/test/kotlin/sources.kt
@@ -1,3 +1,4 @@
 import java.io.File
 
 fun jvmOutput(relativePath: String) = File("../build/classes/kotlin/jvm/main", relativePath)
+fun jsOutput() = File("../build/compileSync/js/main/productionExecutable/kotlin/Poko-poko-tests.js")

--- a/poko-tests/src/commonMain/kotlin/performance/Main.kt
+++ b/poko-tests/src/commonMain/kotlin/performance/Main.kt
@@ -1,0 +1,9 @@
+package performance
+
+/**
+ * An entrypoint for Kotlin/Native and Kotlin/JS.
+ * Should use all types on which you want to assert.
+ */
+fun main() {
+    println(IntAndLong(1, 2L) == IntAndLong(3, 4L))
+}


### PR DESCRIPTION
Before:

```js
protoOf(IntAndLong).equals = function (other) {
  if (this === other)
    return true;
  if (!(other instanceof IntAndLong))
    return false;
  var tmp0_other_with_cast = other instanceof IntAndLong ? other : THROW_CCE();
  if (!(this.v_1 === tmp0_other_with_cast.v_1))
    return false;
  if (!this.w_1.equals(tmp0_other_with_cast.w_1))
    return false;
  return true;
};
```

After:

```js
protoOf(IntAndLong).equals = function (other) {
  if (this === other)
    return true;
  if (!(other instanceof IntAndLong))
    return false;
  if (!(this.v_1 === other.v_1))
    return false;
  if (!this.w_1.equals(other.w_1))
    return false;
  return true;
};
```

Refs #204