### PR TITLE
Test that JDKs newer than 8 use `invokedynamic` for `toString`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,18 +32,21 @@ allprojects {
         }
     }
 
-    val kotlinPluginHandler: AppliedPlugin.() -> Unit = {
-        val javaVersion = JavaVersion.VERSION_1_8
-        project.tasks.withType<JavaCompile>().configureEach {
-            sourceCompatibility = javaVersion.toString()
-            targetCompatibility = javaVersion.toString()
-        }
-        project.tasks.withType<KotlinCompile>().configureEach {
-            compilerOptions {
-                jvmTarget.set(JvmTarget.fromTarget(javaVersion.toString()))
+    // The tests vary their own JVM targets among multiple targets. Do not overwrite them.
+    if (path != ":poko-tests") {
+        val kotlinPluginHandler: AppliedPlugin.() -> Unit = {
+            val javaVersion = JavaVersion.VERSION_1_8
+            project.tasks.withType<JavaCompile>().configureEach {
+                sourceCompatibility = javaVersion.toString()
+                targetCompatibility = javaVersion.toString()
+            }
+            project.tasks.withType<KotlinCompile>().configureEach {
+                compilerOptions {
+                    jvmTarget.set(JvmTarget.fromTarget(javaVersion.toString()))
+                }
             }
         }
+        pluginManager.withPlugin("org.jetbrains.kotlin.jvm", kotlinPluginHandler)
+        pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform", kotlinPluginHandler)
     }
-    pluginManager.withPlugin("org.jetbrains.kotlin.jvm", kotlinPluginHandler)
-    pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform", kotlinPluginHandler)
 }

--- a/poko-tests/performance/build.gradle.kts
+++ b/poko-tests/performance/build.gradle.kts
@@ -11,4 +11,5 @@ dependencies {
 tasks.named("test") {
     dependsOn(":poko-tests:compileProductionExecutableKotlinJs")
     dependsOn(":poko-tests:compileKotlinJvm")
+    dependsOn(":poko-tests:compileKotlinJvm11")
 }

--- a/poko-tests/performance/src/test/kotlin/JvmPerformanceTest.kt
+++ b/poko-tests/performance/src/test/kotlin/JvmPerformanceTest.kt
@@ -13,4 +13,13 @@ class JvmPerformanceTest {
             doesNotContain("java/lang/Integer.hashCode")
         }
     }
+
+    @Test fun `toString uses invokedynamic on modern JDKs`() {
+        val classfile = jvmOutput("performance/IntAndLong.class", version = 11)
+        val bytecode = bytecodeToText(classfile.readBytes())
+        assertThat(bytecode).all {
+            contains("INVOKEDYNAMIC makeConcatWithConstants")
+            doesNotContain("StringBuilder")
+        }
+    }
 }

--- a/poko-tests/performance/src/test/kotlin/sources.kt
+++ b/poko-tests/performance/src/test/kotlin/sources.kt
@@ -1,4 +1,7 @@
 import java.io.File
 
-fun jvmOutput(relativePath: String) = File("../build/classes/kotlin/jvm/main", relativePath)
+fun jvmOutput(relativePath: String, version: Int = -1): File {
+    val number = if (version == -1) "" else "$version"
+    return File("../build/classes/kotlin/jvm$number/main", relativePath)
+}
 fun jsOutput() = File("../build/compileSync/js/main/productionExecutable/kotlin/Poko-poko-tests.js")


### PR DESCRIPTION
Just ensuring we don't regress this performance-related optimization by accident.