### PR TITLE
Do not invoke `hashCode` for `UInt`

### DIFF
--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
@@ -149,7 +149,7 @@ private fun IrBlockBodyBuilder.getHashCodeOf(
     if (property.type.isUInt()) {
         val uintToInt = referenceClass(StandardNames.FqNames.uInt)!!
             .functions
-            .first { it.owner.name.asString() == "toInt" }
+            .single { it.owner.name.asString() == "toInt" }
         return irCall(uintToInt).apply {
             dispatchReceiver = value
         }

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
@@ -2,6 +2,7 @@ package dev.drewhamilton.poko.ir
 
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.builtins.PrimitiveType
+import org.jetbrains.kotlin.builtins.StandardNames
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.ir.builders.IrBlockBodyBuilder
 import org.jetbrains.kotlin.ir.builders.IrGeneratorContextInterface
@@ -33,6 +34,7 @@ import org.jetbrains.kotlin.ir.types.classifierOrFail
 import org.jetbrains.kotlin.ir.types.classifierOrNull
 import org.jetbrains.kotlin.ir.types.isInt
 import org.jetbrains.kotlin.ir.types.isNullable
+import org.jetbrains.kotlin.ir.types.isUInt
 import org.jetbrains.kotlin.ir.util.functions
 import org.jetbrains.kotlin.ir.util.render
 import org.jetbrains.kotlin.name.CallableId
@@ -143,6 +145,14 @@ private fun IrBlockBodyBuilder.getHashCodeOf(
     // Fast path for integers which are already their own hashCode value.
     if (property.type.isInt()) {
         return value
+    }
+    if (property.type.isUInt()) {
+        val uintToInt = referenceClass(StandardNames.FqNames.uInt)!!
+            .functions
+            .first { it.owner.name.asString() == "toInt" }
+        return irCall(uintToInt).apply {
+            dispatchReceiver = value
+        }
     }
 
     val hasArrayContentBasedAnnotation = property.hasArrayContentBasedAnnotation()

--- a/poko-tests/performance/src/test/kotlin/JvmPerformanceTest.kt
+++ b/poko-tests/performance/src/test/kotlin/JvmPerformanceTest.kt
@@ -14,6 +14,15 @@ class JvmPerformanceTest {
         }
     }
 
+    @Test fun `uint property does not emit hashCode method invocation`() {
+        val classfile = jvmOutput("performance/UIntAndLong.class")
+        val bytecode = bytecodeToText(classfile.readBytes())
+        assertThat(bytecode).all {
+            contains("java/lang/Long.hashCode")
+            doesNotContain("kotlin/UInt.hashCode-impl")
+        }
+    }
+
     @Test fun `toString uses invokedynamic on modern JDKs`() {
         val classfile = jvmOutput("performance/IntAndLong.class", version = 11)
         val bytecode = bytecodeToText(classfile.readBytes())

--- a/poko-tests/src/commonMain/kotlin/performance/UIntAndLong.kt
+++ b/poko-tests/src/commonMain/kotlin/performance/UIntAndLong.kt
@@ -1,0 +1,9 @@
+package performance
+
+import dev.drewhamilton.poko.Poko
+
+@Suppress("unused")
+@Poko class UIntAndLong(
+    val uint: UInt,
+    val long: Long,
+)


### PR DESCRIPTION
It is backed by an `Int` whose `hashCode` is the identity function.

Before:

    public int hashCode();
      Code:
         0: aload_0
         1: getfield      #13                 // Field uint:I
         4: invokestatic  #35                 // Method kotlin/UInt."hashCode-impl":(I)I
         7: istore_1
         8: iload_1
         9: bipush        31
        11: imul
        12: aload_0
        13: getfield      #17                 // Field long:J
        16: invokestatic  #40                 // Method java/lang/Long.hashCode:(J)I
        19: iadd
        20: istore_1
        21: iload_1
        22: ireturn

After:

    public int hashCode();
      Code:
         0: aload_0
         1: getfield      #13                 // Field uint:I
         4: istore_1
         5: iload_1
         6: bipush        31
         8: imul
         9: aload_0
        10: getfield      #17                 // Field long:J
        13: invokestatic  #34                 // Method java/lang/Long.hashCode:(J)I
        16: iadd
        17: istore_1
        18: iload_1
        19: ireturn

Refs #204