### PR TITLE
Test boolean properties in ComplexTest

### DIFF
--- a/poko-tests/src/commonMain/kotlin/data/Complex.kt
+++ b/poko-tests/src/commonMain/kotlin/data/Complex.kt
@@ -7,6 +7,8 @@ package data
 data class Complex<T>(
     val referenceType: String,
     val nullableReferenceType: String?,
+    val boolean: Boolean,
+    val nullableBoolean: Boolean?,
     val int: Int,
     val nullableInt: Int?,
     val long: Long,

--- a/poko-tests/src/commonMain/kotlin/poko/Complex.kt
+++ b/poko-tests/src/commonMain/kotlin/poko/Complex.kt
@@ -6,6 +6,8 @@ import dev.drewhamilton.poko.Poko
 @Poko class Complex<T>(
     val referenceType: String,
     val nullableReferenceType: String?,
+    val boolean: Boolean,
+    val nullableBoolean: Boolean?,
     val int: Int,
     val nullableInt: Int?,
     val long: Long,

--- a/poko-tests/src/commonTest/kotlin/ComplexTest.kt
+++ b/poko-tests/src/commonTest/kotlin/ComplexTest.kt
@@ -16,6 +16,8 @@ class ComplexTest {
         val a = ComplexPoko(
             referenceType = "Text",
             nullableReferenceType = null,
+            boolean = true,
+            nullableBoolean = null,
             int = 2,
             nullableInt = null,
             long = 12345L,
@@ -33,6 +35,8 @@ class ComplexTest {
         val b = ComplexPoko(
             referenceType = "Text",
             nullableReferenceType = null,
+            boolean = true,
+            nullableBoolean = null,
             int = 2,
             nullableInt = null,
             long = 12345L,
@@ -62,6 +66,8 @@ class ComplexTest {
         val a = ComplexPoko(
             referenceType = "Text",
             nullableReferenceType = null,
+            boolean = true,
+            nullableBoolean = null,
             int = 2,
             nullableInt = null,
             long = 12345L,
@@ -79,6 +85,8 @@ class ComplexTest {
         val b = ComplexPoko(
             referenceType = "Text",
             nullableReferenceType = "non-null",
+            boolean = true,
+            nullableBoolean = null,
             int = 2,
             nullableInt = null,
             long = 12345L,
@@ -103,6 +111,8 @@ class ComplexTest {
         val poko = ComplexPoko(
             referenceType = "Text",
             nullableReferenceType = null,
+            boolean = true,
+            nullableBoolean = null,
             int = 2,
             nullableInt = null,
             long = 12345L,
@@ -120,6 +130,8 @@ class ComplexTest {
         val data = ComplexData(
             referenceType = "Text",
             nullableReferenceType = null,
+            boolean = true,
+            nullableBoolean = null,
             int = 2,
             nullableInt = null,
             long = 12345L,


### PR DESCRIPTION
I think this is failing because of the previous behavior of [KT-62383](https://youtrack.jetbrains.com/issue/KT-62383), and thus depends on #233. Apparently we've had different `hashCode` values from data classes when boolean properties are involved. Oops!