### PR TITLE
Kotlin 2.0.0-RC3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: Test
-        run: ./gradlew :poko-tests:jvmTest :poko-tests:jvmK2Test --stacktrace
+        run: ./gradlew :poko-tests:jvmTest :poko-tests-without-k2:jvmTest --stacktrace
         env:
           poko_tests_jvm_toolchain_version: ${{ matrix.poko_tests_jvm_toolchain_version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [ main, "drew/kotlin-2.0" ]
+    branches: [ main ]
     tags: [ "*" ]
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "drew/kotlin-2.0" ]
     tags: [ "*" ]
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ gradle-app.setting
 # gradle/wrapper/gradle-wrapper.properties
 
 # End of https://www.gitignore.io/api/gradle,intellij
+
+# Kotlin
+.kotlin

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.0-RC1" />
+    <option name="version" value="2.0.0-RC2" />
   </component>
 </project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.0-Beta1" />
+    <option name="version" value="2.0.0-Beta2" />
   </component>
 </project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.0-RC2" />
+    <option name="version" value="2.0.0-RC3" />
   </component>
 </project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.0-Beta4" />
+    <option name="version" value="2.0.0-Beta5" />
   </component>
 </project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.0-Beta5" />
+    <option name="version" value="2.0.0-RC1" />
   </component>
 </project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.0-Beta2" />
+    <option name="version" value="2.0.0-Beta4" />
   </component>
 </project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.24" />
+    <option name="version" value="2.0.0-Beta1" />
   </component>
 </project>

--- a/build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildPlugin.kt
+++ b/build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildPlugin.kt
@@ -8,8 +8,8 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.AppliedPlugin
 import org.gradle.kotlin.dsl.buildConfigField
-import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
 import org.jetbrains.kotlin.gradle.dsl.KotlinTopLevelExtensionConfig
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 private val Project.pokoGroupId get() = property("PUBLISH_GROUP") as String
 private val Project.pokoVersion get() = property("PUBLISH_VERSION") as String
@@ -31,8 +31,8 @@ class PokoBuildPlugin : Plugin<Project> {
     }
 
     private fun commonKotlinConfiguration(project: Project) {
-        project.tasks.withType(KotlinCompile::class.java).configureEach {
-            kotlinOptions.freeCompilerArgs += "-progressive"
+        project.tasks.withType(KotlinCompilationTask::class.java).configureEach {
+            compilerOptions.freeCompilerArgs.add("-progressive")
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,19 +9,6 @@ plugins {
     alias(libs.plugins.ksp) apply false
 }
 
-plugins.withType<NodeJsRootPlugin> {
-    extensions.getByType<NodeJsRootExtension>().apply {
-        // WASM requires a canary Node.js version. This is the last v22 nightly that supports
-        // darwin-arm64, darwin-x64 and win-x64 artifacts:
-        version = "22.0.0-nightly20240410c82f3c9e80"
-        downloadBaseUrl = "https://nodejs.org/download/nightly"
-    }
-}
-
-tasks.withType<KotlinNpmInstallTask>().configureEach {
-    args.add("--ignore-engines")
-}
-
 allprojects {
     setUpLocalSigning()
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,19 @@ plugins {
     alias(libs.plugins.ksp) apply false
 }
 
+plugins.withType<NodeJsRootPlugin> {
+    extensions.getByType<NodeJsRootExtension>().apply {
+        // WASM requires a canary Node.js version. This is the last v22 nightly that supports
+        // darwin-arm64, darwin-x64 and win-x64 artifacts:
+        version = "22.0.0-nightly20240410c82f3c9e80"
+        downloadBaseUrl = "https://nodejs.org/download/nightly"
+    }
+}
+
+tasks.withType<KotlinNpmInstallTask>().configureEach {
+    args.add("--ignore-engines")
+}
+
 allprojects {
     setUpLocalSigning()
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ allprojects {
     }
 
     // The tests vary their own JVM targets among multiple targets. Do not overwrite them.
-    if (path != ":poko-tests") {
+    if (path !in setOf(":poko-tests", ":poko-tests-without-k2")) {
         val kotlinPluginHandler: AppliedPlugin.() -> Unit = {
             val javaVersion = JavaVersion.VERSION_1_8
             project.tasks.withType<JavaCompile>().configureEach {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 PUBLISH_GROUP=dev.drewhamilton.poko
-PUBLISH_VERSION=0.15.4-SNAPSHOT
+PUBLISH_VERSION=0.16.0-SNAPSHOT
 
 # Uncomment to enable snapshot dependencies:
 #snapshots_repository=https://oss.sonatype.org/content/repositories/snapshots

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 # https://androidx.dev/storage/compose-compiler/repository for versions matching new Kotlin versions:
-androidx-compose-compiler = "1.5.6-dev-k2.0.0-Beta1-06a03be2b42"
+androidx-compose-compiler = "1.5.8-dev-k2.0.0-Beta2-99ed868a0f8"
 androidx-compose-runtime = "1.6.7"
 kotlin = "2.0.0-Beta2"
 kotlinCompileTesting = "1.5.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 androidx-compose-runtime = "1.6.7"
-kotlin = "2.0.0-RC1"
+kotlin = "2.0.0-RC2"
 kotlinCompileTesting = "1.5.1"
 kotlinCompileTestingFork = "0.5.0-alpha07"
 # https://github.com/google/ksp/releases:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # https://androidx.dev/storage/compose-compiler/repository for versions matching new Kotlin versions:
 androidx-compose-compiler = "1.5.6-dev-k2.0.0-Beta1-06a03be2b42"
 androidx-compose-runtime = "1.6.7"
-kotlin = "2.0.0-Beta1"
+kotlin = "2.0.0-Beta2"
 kotlinCompileTesting = "1.5.1"
 kotlinCompileTestingFork = "0.4.1"
 # https://github.com/google/ksp/releases:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,17 +1,14 @@
 [versions]
 
-# https://androidx.dev/storage/compose-compiler/repository for versions matching new Kotlin versions:
-androidx-compose-compiler = "1.5.11-dev-k2.0.0-Beta5-b5a216d0ac6"
 androidx-compose-runtime = "1.6.7"
-kotlin = "2.0.0-Beta5"
+kotlin = "2.0.0-RC1"
 kotlinCompileTesting = "1.5.1"
-kotlinCompileTestingFork = "0.4.1"
+kotlinCompileTestingFork = "0.5.0-alpha07"
 # https://github.com/google/ksp/releases:
-ksp = "2.0.0-Beta5-1.0.19"
+ksp = "2.0.0-RC1-1.0.20"
 
 [libraries]
 
-androidx-compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "androidx-compose-compiler" }
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "androidx-compose-runtime" }
 
 autoService-annotations = { module = "com.google.auto.service:auto-service-annotations", version = "1.1.1" }
@@ -41,5 +38,6 @@ android-library = { id = "com.android.library", version = "8.4.0" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+kotlin-compose-plugin = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinx-binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.14.0" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ kotlin = "2.0.0-Beta2"
 kotlinCompileTesting = "1.5.1"
 kotlinCompileTestingFork = "0.4.1"
 # https://github.com/google/ksp/releases:
-ksp = "2.0.0-Beta1-1.0.15"
+ksp = "2.0.0-Beta2-1.0.16"
 
 [libraries]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,13 @@
 [versions]
 
 # https://androidx.dev/storage/compose-compiler/repository for versions matching new Kotlin versions:
-androidx-compose-compiler = "1.5.9-dev-k2.0.0-Beta3-7c5ec6895a0"
+androidx-compose-compiler = "1.5.11-dev-k2.0.0-Beta4-21f5e479a96"
 androidx-compose-runtime = "1.6.7"
-kotlin = "2.0.0-Beta3"
+kotlin = "2.0.0-Beta4"
 kotlinCompileTesting = "1.5.1"
 kotlinCompileTestingFork = "0.4.1"
 # https://github.com/google/ksp/releases:
-ksp = "2.0.0-Beta3-1.0.17"
+ksp = "2.0.0-Beta4-1.0.17"
 
 [libraries]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,13 @@
 [versions]
 
 # https://androidx.dev/storage/compose-compiler/repository for versions matching new Kotlin versions:
-androidx-compose-compiler = "1.5.14"
+androidx-compose-compiler = "1.5.5-dev-k2.0.0-Beta1-06b8ae672a4"
 androidx-compose-runtime = "1.6.7"
-kotlin = "1.9.24"
+kotlin = "2.0.0-Beta1"
 kotlinCompileTesting = "1.5.1"
 kotlinCompileTestingFork = "0.4.1"
 # https://github.com/google/ksp/releases:
-ksp = "1.9.24-1.0.20"
+ksp = "2.0.0-Beta1-1.0.15"
 
 [libraries]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 # https://androidx.dev/storage/compose-compiler/repository for versions matching new Kotlin versions:
-androidx-compose-compiler = "1.5.5-dev-k2.0.0-Beta1-06b8ae672a4"
+androidx-compose-compiler = "1.5.6-dev-k2.0.0-Beta1-06a03be2b42"
 androidx-compose-runtime = "1.6.7"
 kotlin = "2.0.0-Beta1"
 kotlinCompileTesting = "1.5.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,13 @@
 [versions]
 
 # https://androidx.dev/storage/compose-compiler/repository for versions matching new Kotlin versions:
-androidx-compose-compiler = "1.5.8-dev-k2.0.0-Beta2-99ed868a0f8"
+androidx-compose-compiler = "1.5.9-dev-k2.0.0-Beta3-7c5ec6895a0"
 androidx-compose-runtime = "1.6.7"
-kotlin = "2.0.0-Beta2"
+kotlin = "2.0.0-Beta3"
 kotlinCompileTesting = "1.5.1"
 kotlinCompileTestingFork = "0.4.1"
 # https://github.com/google/ksp/releases:
-ksp = "2.0.0-Beta2-1.0.16"
+ksp = "2.0.0-Beta3-1.0.17"
 
 [libraries]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ kotlin = "2.0.0-RC2"
 kotlinCompileTesting = "1.5.1"
 kotlinCompileTestingFork = "0.5.0-alpha07"
 # https://github.com/google/ksp/releases:
-ksp = "2.0.0-RC1-1.0.20"
+ksp = "2.0.0-RC2-1.0.20"
 
 [libraries]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,13 @@
 [versions]
 
 # https://androidx.dev/storage/compose-compiler/repository for versions matching new Kotlin versions:
-androidx-compose-compiler = "1.5.11-dev-k2.0.0-Beta4-21f5e479a96"
+androidx-compose-compiler = "1.5.11-dev-k2.0.0-Beta5-b5a216d0ac6"
 androidx-compose-runtime = "1.6.7"
-kotlin = "2.0.0-Beta4"
+kotlin = "2.0.0-Beta5"
 kotlinCompileTesting = "1.5.1"
 kotlinCompileTestingFork = "0.4.1"
 # https://github.com/google/ksp/releases:
-ksp = "2.0.0-Beta4-1.0.19"
+ksp = "2.0.0-Beta5-1.0.19"
 
 [libraries]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ kotlin = "2.0.0-Beta4"
 kotlinCompileTesting = "1.5.1"
 kotlinCompileTestingFork = "0.4.1"
 # https://github.com/google/ksp/releases:
-ksp = "2.0.0-Beta4-1.0.17"
+ksp = "2.0.0-Beta4-1.0.19"
 
 [libraries]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
 
 androidx-compose-runtime = "1.6.7"
-kotlin = "2.0.0-RC2"
+kotlin = "2.0.0-RC3"
 kotlinCompileTesting = "1.5.1"
 kotlinCompileTestingFork = "0.5.0-alpha07"
 # https://github.com/google/ksp/releases:
-ksp = "2.0.0-RC2-1.0.20"
+ksp = "2.0.0-RC3-1.0.20"
 
 [libraries]
 

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -42,14 +42,6 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
-  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
-  dependencies:
-    balanced-match "^1.0.0"
-    concat-map "0.0.1"
-
 brace-expansion@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
@@ -122,11 +114,6 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
-concat-map@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
 debug@4.3.4:
   version "4.3.4"
@@ -207,17 +194,16 @@ glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob@7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
-  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
+glob@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
+  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
     inherits "2"
-    minimatch "^3.0.4"
+    minimatch "^5.0.1"
     once "^1.3.0"
-    path-is-absolute "^1.0.0"
 
 has-flag@^4.0.0:
   version "4.0.0"
@@ -310,17 +296,17 @@ minimatch@5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^3.0.4:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+minimatch@^5.0.1:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
+  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
   dependencies:
-    brace-expansion "^1.1.7"
+    brace-expansion "^2.0.1"
 
-mocha@10.2.0:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.2.0.tgz#1fd4a7c32ba5ac372e03a17eef435bd00e5c68b8"
-  integrity sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==
+mocha@10.3.0:
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.3.0.tgz#0e185c49e6dccf582035c05fa91084a4ff6e3fe9"
+  integrity sha512-uF2XJs+7xSLsrmIvn37i/wnc91nw7XjOQB8ccyx5aEgdnohr7n+rEiZP23WkCYHjilR6+EboEnbq/ZQDz4LSbg==
   dependencies:
     ansi-colors "4.1.1"
     browser-stdout "1.3.1"
@@ -329,13 +315,12 @@ mocha@10.2.0:
     diff "5.0.0"
     escape-string-regexp "4.0.0"
     find-up "5.0.0"
-    glob "7.2.0"
+    glob "8.1.0"
     he "1.2.0"
     js-yaml "4.1.0"
     log-symbols "4.1.0"
     minimatch "5.0.1"
     ms "2.1.3"
-    nanoid "3.3.3"
     serialize-javascript "6.0.0"
     strip-json-comments "3.1.1"
     supports-color "8.1.1"
@@ -353,11 +338,6 @@ ms@2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-
-nanoid@3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
-  integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
@@ -389,11 +369,6 @@ path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
-
-path-is-absolute@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
-  integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
 picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.3.1"
@@ -486,10 +461,10 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-typescript@5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
-  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+typescript@5.4.3:
+  version "5.4.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.3.tgz#5c6fedd4c87bee01cd7a528a30145521f8e0feff"
+  integrity sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==
 
 workerpool@6.2.1:
   version "6.2.1"

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/PokoFirCheckersExtension.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/PokoFirCheckersExtension.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.diagnostics.rendering.BaseDiagnosticRendererFactory
 import org.jetbrains.kotlin.diagnostics.rendering.RootDiagnosticRendererFactory
 import org.jetbrains.kotlin.diagnostics.reportOn
 import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.DeclarationCheckers
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirRegularClassChecker
@@ -32,7 +33,9 @@ internal class PokoFirCheckersExtension(
                 setOf(PokoFirRegularClassChecker)
         }
 
-    internal object PokoFirRegularClassChecker : FirRegularClassChecker() {
+    internal object PokoFirRegularClassChecker : FirRegularClassChecker(
+        mppKind = MppCheckerKind.Common,
+    ) {
         override fun check(
             declaration: FirRegularClass,
             context: CheckerContext,

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
@@ -23,8 +23,6 @@ import org.jetbrains.kotlin.ir.util.isFakeOverride
 import org.jetbrains.kotlin.ir.util.primaryConstructor
 import org.jetbrains.kotlin.ir.util.properties
 import org.jetbrains.kotlin.name.ClassId
-import org.jetbrains.kotlin.psi.KtParameter
-import org.jetbrains.kotlin.resolve.source.getPsi
 
 internal class PokoMembersTransformer(
     private val pokoAnnotationName: ClassId,
@@ -111,15 +109,8 @@ internal class PokoMembersTransformer(
         val properties = parent.properties
             .toList()
             .filter {
-                val metadata = it.metadata
-                if (metadata is FirMetadataSource.Property) {
-                    // Using K2:
-                    metadata.fir.source?.kind is KtFakeSourceElementKind.PropertyFromParameter
-                } else {
-                    // Not using K2:
-                    @OptIn(ObsoleteDescriptorBasedAPI::class)
-                    it.symbol.descriptor.source.getPsi() is KtParameter
-                }
+                val metadata = it.metadata as FirMetadataSource.Property
+                metadata.fir.source?.kind is KtFakeSourceElementKind.PropertyFromParameter
             }
         if (properties.isEmpty()) {
             messageCollector.log("No primary constructor properties")

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrProperty
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
-import org.jetbrains.kotlin.ir.declarations.impl.IrValueParameterImpl
+import org.jetbrains.kotlin.ir.declarations.impl.IrFactoryImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrValueParameterSymbolImpl
 import org.jetbrains.kotlin.ir.types.createType
 import org.jetbrains.kotlin.ir.util.hasAnnotation
@@ -151,7 +151,7 @@ internal class PokoMembersTransformer(
     private fun IrFunction.mutateWithNewDispatchReceiverParameterForParentClass() {
         val parentClass = parent as IrClass
         val originalReceiver = requireNotNull(dispatchReceiverParameter)
-        dispatchReceiverParameter = IrValueParameterImpl(
+        dispatchReceiverParameter = IrFactoryImpl.createValueParameter(
             startOffset = originalReceiver.startOffset,
             endOffset = originalReceiver.endOffset,
             origin = originalReceiver.origin,

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
@@ -23,6 +23,8 @@ import org.jetbrains.kotlin.ir.util.isFakeOverride
 import org.jetbrains.kotlin.ir.util.primaryConstructor
 import org.jetbrains.kotlin.ir.util.properties
 import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.resolve.source.getPsi
 
 internal class PokoMembersTransformer(
     private val pokoAnnotationName: ClassId,
@@ -109,8 +111,15 @@ internal class PokoMembersTransformer(
         val properties = parent.properties
             .toList()
             .filter {
-                val metadata = it.metadata as FirMetadataSource.Property
-                metadata.fir.source?.kind is KtFakeSourceElementKind.PropertyFromParameter
+                val metadata = it.metadata
+                if (metadata is FirMetadataSource.Property) {
+                    // Using K2:
+                    metadata.fir.source?.kind is KtFakeSourceElementKind.PropertyFromParameter
+                } else {
+                    // Not using K2:
+                    @OptIn(ObsoleteDescriptorBasedAPI::class)
+                    it.symbol.descriptor.source.getPsi() is KtParameter
+                }
             }
         if (properties.isEmpty()) {
             messageCollector.log("No primary constructor properties")

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoOrigin.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoOrigin.kt
@@ -1,5 +1,13 @@
 package dev.drewhamilton.poko.ir
 
-import org.jetbrains.kotlin.ir.declarations.IrDeclarationOriginImpl
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
 
-internal object PokoOrigin : IrDeclarationOriginImpl("GENERATED_POKO_CLASS_MEMBER")
+internal object PokoOrigin : IrDeclarationOrigin, ReadOnlyProperty<Any?, PokoOrigin> {
+    override val name: String = "GENERATED_POKO_CLASS_MEMBER"
+
+    override fun toString(): String = name
+
+    override fun getValue(thisRef: Any?, property: KProperty<*>): PokoOrigin = this
+}

--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
@@ -232,7 +232,10 @@ class PokoCompilerPluginTest(
         verbose = false
         jvmTarget = JvmTarget.JVM_1_8.description
         if (k2) {
-            languageVersion = "2.0"
+            supportsK2 = true
+        } else {
+            supportsK2 = false
+            languageVersion = "1.9"
         }
 
         val commandLineProcessor = PokoCommandLineProcessor()

--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
@@ -4,6 +4,8 @@ import assertk.all
 import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.isEqualTo
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import com.tschuchort.compiletesting.JvmCompilationResult
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.PluginOption
@@ -17,9 +19,13 @@ import org.junit.Assert.fail
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
 
 @OptIn(ExperimentalCompilerApi::class)
-class PokoCompilerPluginTest {
+@RunWith(TestParameterInjector::class)
+class PokoCompilerPluginTest(
+    @TestParameter private val k2: Boolean,
+) {
 
     @JvmField
     @Rule var temporaryFolder: TemporaryFolder = TemporaryFolder()
@@ -225,7 +231,9 @@ class PokoCompilerPluginTest {
         sources = sourceFiles.asList()
         verbose = false
         jvmTarget = JvmTarget.JVM_1_8.description
-        languageVersion = "2.0"
+        if (k2) {
+            languageVersion = "2.0"
+        }
 
         val commandLineProcessor = PokoCommandLineProcessor()
         commandLineProcessors = listOf(commandLineProcessor)

--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
@@ -4,8 +4,6 @@ import assertk.all
 import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.isEqualTo
-import com.google.testing.junit.testparameterinjector.TestParameter
-import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import com.tschuchort.compiletesting.JvmCompilationResult
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.PluginOption
@@ -19,13 +17,9 @@ import org.junit.Assert.fail
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import org.junit.runner.RunWith
 
 @OptIn(ExperimentalCompilerApi::class)
-@RunWith(TestParameterInjector::class)
-class PokoCompilerPluginTest(
-    @TestParameter private val k2: Boolean,
-) {
+class PokoCompilerPluginTest {
 
     @JvmField
     @Rule var temporaryFolder: TemporaryFolder = TemporaryFolder()
@@ -231,9 +225,7 @@ class PokoCompilerPluginTest(
         sources = sourceFiles.asList()
         verbose = false
         jvmTarget = JvmTarget.JVM_1_8.description
-        if (k2) {
-            languageVersion = "2.0"
-        }
+        languageVersion = "2.0"
 
         val commandLineProcessor = PokoCommandLineProcessor()
         commandLineProcessors = listOf(commandLineProcessor)

--- a/poko-tests-without-k2/build.gradle.kts
+++ b/poko-tests-without-k2/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.plugin.NATIVE_COMPILER_PLUGIN_CLASSPATH_CONFIGURATION_NAME
 import org.jetbrains.kotlin.gradle.plugin.PLUGIN_CLASSPATH_CONFIGURATION_NAME
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -40,7 +41,9 @@ kotlin {
   tvosX64()
   tvosSimulatorArm64()
 
+  @OptIn(ExperimentalWasmDsl::class)
   wasmJs().nodejs()
+  @OptIn(ExperimentalWasmDsl::class)
   wasmWasi().nodejs()
 
   watchosArm32()

--- a/poko-tests-without-k2/build.gradle.kts
+++ b/poko-tests-without-k2/build.gradle.kts
@@ -1,8 +1,14 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.plugin.NATIVE_COMPILER_PLUGIN_CLASSPATH_CONFIGURATION_NAME
 import org.jetbrains.kotlin.gradle.plugin.PLUGIN_CLASSPATH_CONFIGURATION_NAME
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+  compilerOptions.languageVersion.set(KotlinVersion.KOTLIN_1_9)
 }
 
 val jvmToolchainVersion: Int? = System.getenv()["poko_tests_jvm_toolchain_version"]?.toInt()

--- a/poko-tests-without-k2/src/commonMain/kotlin/Super.kt
+++ b/poko-tests-without-k2/src/commonMain/kotlin/Super.kt
@@ -1,0 +1,5 @@
+abstract class Super {
+    override fun equals(other: Any?): Boolean = other == true
+    override fun hashCode(): Int = 50934
+    override fun toString(): String = "superclass"
+}

--- a/poko-tests-without-k2/src/commonMain/kotlin/data/AnyArrayHolder.kt
+++ b/poko-tests-without-k2/src/commonMain/kotlin/data/AnyArrayHolder.kt
@@ -1,0 +1,103 @@
+package data
+
+/**
+ * Data classes don't implement array content checks, so [equals], [hashCode], and [toString] must
+ * be written by hand.
+ */
+@Suppress("Unused")
+data class AnyArrayHolder(
+    val any: Any,
+    val nullableAny: Any?,
+    val trailingProperty: String,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other)
+            return true
+
+        if (other !is AnyArrayHolder)
+            return false
+
+        if (!this.any.arrayContentDeepEquals(other.any))
+            return false
+
+        if (!this.nullableAny.arrayContentDeepEquals(other.nullableAny))
+            return false
+
+        if (this.trailingProperty != other.trailingProperty)
+            return false
+
+        return true
+    }
+
+    @Suppress("NOTHING_TO_INLINE")
+    private inline fun Any?.arrayContentDeepEquals(other: Any?): Boolean {
+        return when (this) {
+            is Array<*> -> other is Array<*> && this.contentDeepEquals(other)
+            is BooleanArray -> other is BooleanArray && this.contentEquals(other)
+            is ByteArray -> other is ByteArray && this.contentEquals(other)
+            is CharArray -> other is CharArray && this.contentEquals(other)
+            is ShortArray -> other is ShortArray && this.contentEquals(other)
+            is IntArray -> other is IntArray && this.contentEquals(other)
+            is LongArray -> other is LongArray && this.contentEquals(other)
+            is FloatArray -> other is FloatArray && this.contentEquals(other)
+            is DoubleArray -> other is DoubleArray && this.contentEquals(other)
+            else -> this == other
+        }
+    }
+
+    override fun hashCode(): Int {
+        var result = any.arrayContentDeepHashCode()
+
+        result = result * 31 + nullableAny.arrayContentDeepHashCode()
+        result = result * 31 + trailingProperty.hashCode()
+
+        return result
+    }
+
+    @Suppress("NOTHING_TO_INLINE")
+    private inline fun Any?.arrayContentDeepHashCode(): Int {
+        return when (this) {
+            is Array<*> -> this.contentDeepHashCode()
+            is BooleanArray -> this.contentHashCode()
+            is ByteArray -> this.contentHashCode()
+            is CharArray -> this.contentHashCode()
+            is ShortArray -> this.contentHashCode()
+            is IntArray -> this.contentHashCode()
+            is LongArray -> this.contentHashCode()
+            is FloatArray -> this.contentHashCode()
+            is DoubleArray -> this.contentHashCode()
+            else -> this.hashCode()
+        }
+    }
+
+    override fun toString(): String {
+        return StringBuilder()
+            .append("AnyArrayHolder(")
+            .append("any=")
+            .append(any.arrayContentDeepToString())
+            .append(", ")
+            .append("nullableAny=")
+            .append(nullableAny.arrayContentDeepToString())
+            .append(", ")
+            .append("trailingProperty=")
+            .append(trailingProperty)
+            .append(")")
+            .toString()
+    }
+
+    @Suppress("NOTHING_TO_INLINE")
+    private inline fun Any?.arrayContentDeepToString(): String {
+        return when (this) {
+            is Array<*> -> this.contentDeepToString()
+            is BooleanArray -> this.contentToString()
+            is ByteArray -> this.contentToString()
+            is CharArray -> this.contentToString()
+            is ShortArray -> this.contentToString()
+            is IntArray -> this.contentToString()
+            is LongArray -> this.contentToString()
+            is FloatArray -> this.contentToString()
+            is DoubleArray -> this.contentToString()
+            else -> this.toString()
+        }
+    }
+}

--- a/poko-tests-without-k2/src/commonMain/kotlin/data/Complex.kt
+++ b/poko-tests-without-k2/src/commonMain/kotlin/data/Complex.kt
@@ -1,0 +1,25 @@
+package data
+
+/**
+ * A data class version of [poko.Complex], useful for comparing generated [toString], [equals], and [hashCode].
+ */
+@Suppress("Unused", "ArrayInDataClass")
+data class Complex<T>(
+    val referenceType: String,
+    val nullableReferenceType: String?,
+    val boolean: Boolean,
+    val nullableBoolean: Boolean?,
+    val int: Int,
+    val nullableInt: Int?,
+    val long: Long,
+    val float: Float,
+    val double: Double,
+    val arrayReferenceType: Array<String>,
+    val nullableArrayReferenceType: Array<String>?,
+    val arrayPrimitiveType: IntArray,
+    val nullableArrayPrimitiveType: IntArray?,
+    val genericCollectionType: List<T>,
+    val nullableGenericCollectionType: List<T>?,
+    val genericType: T,
+    val nullableGenericType: T?
+)

--- a/poko-tests-without-k2/src/commonMain/kotlin/data/ExplicitDeclarations.kt
+++ b/poko-tests-without-k2/src/commonMain/kotlin/data/ExplicitDeclarations.kt
@@ -1,0 +1,9 @@
+package data
+
+data class ExplicitDeclarations(
+    private val string: String
+) {
+    override fun toString() = string
+    override fun equals(other: Any?) = other is ExplicitDeclarations && other.string.length == string.length
+    override fun hashCode() = string.length
+}

--- a/poko-tests-without-k2/src/commonMain/kotlin/data/Nested.kt
+++ b/poko-tests-without-k2/src/commonMain/kotlin/data/Nested.kt
@@ -1,0 +1,7 @@
+package data
+
+class OuterClass {
+    data class Nested(
+        val value: String
+    )
+}

--- a/poko-tests-without-k2/src/commonMain/kotlin/data/Simple.kt
+++ b/poko-tests-without-k2/src/commonMain/kotlin/data/Simple.kt
@@ -1,0 +1,11 @@
+package data
+
+/**
+ * A data class version of [poko.Simple], useful for comparing generated [toString], [equals], and [hashCode].
+ */
+@Suppress("unused")
+data class Simple(
+    val int: Int,
+    val requiredString: String,
+    val optionalString: String?
+)

--- a/poko-tests-without-k2/src/commonMain/kotlin/data/SuperclassDeclarations.kt
+++ b/poko-tests-without-k2/src/commonMain/kotlin/data/SuperclassDeclarations.kt
@@ -1,0 +1,7 @@
+package data
+
+import Super
+
+data class SuperclassDeclarations(
+    val number: Number
+) : Super()

--- a/poko-tests-without-k2/src/commonMain/kotlin/performance/IntAndLong.kt
+++ b/poko-tests-without-k2/src/commonMain/kotlin/performance/IntAndLong.kt
@@ -1,0 +1,9 @@
+package performance
+
+import dev.drewhamilton.poko.Poko
+
+@Suppress("unused")
+@Poko class IntAndLong(
+    val int: Int,
+    val long: Long,
+)

--- a/poko-tests-without-k2/src/commonMain/kotlin/performance/Main.kt
+++ b/poko-tests-without-k2/src/commonMain/kotlin/performance/Main.kt
@@ -1,0 +1,9 @@
+package performance
+
+/**
+ * An entrypoint for Kotlin/Native and Kotlin/JS.
+ * Should use all types on which you want to assert.
+ */
+fun main() {
+    println(IntAndLong(1, 2L) == IntAndLong(3, 4L))
+}

--- a/poko-tests-without-k2/src/commonMain/kotlin/performance/UIntAndLong.kt
+++ b/poko-tests-without-k2/src/commonMain/kotlin/performance/UIntAndLong.kt
@@ -1,0 +1,9 @@
+package performance
+
+import dev.drewhamilton.poko.Poko
+
+@Suppress("unused")
+@Poko class UIntAndLong(
+    val uint: UInt,
+    val long: Long,
+)

--- a/poko-tests-without-k2/src/commonMain/kotlin/poko/AnyArrayHolder.kt
+++ b/poko-tests-without-k2/src/commonMain/kotlin/poko/AnyArrayHolder.kt
@@ -1,0 +1,13 @@
+package poko
+
+import dev.drewhamilton.poko.ArrayContentBased
+import dev.drewhamilton.poko.ArrayContentSupport
+import dev.drewhamilton.poko.Poko
+
+@Suppress("Unused")
+@OptIn(ArrayContentSupport::class)
+@Poko class AnyArrayHolder(
+    @ArrayContentBased val any: Any,
+    @ArrayContentBased val nullableAny: Any?,
+    val trailingProperty: String,
+)

--- a/poko-tests-without-k2/src/commonMain/kotlin/poko/ArrayHolder.kt
+++ b/poko-tests-without-k2/src/commonMain/kotlin/poko/ArrayHolder.kt
@@ -1,0 +1,30 @@
+package poko
+
+import dev.drewhamilton.poko.ArrayContentBased
+import dev.drewhamilton.poko.ArrayContentSupport
+import dev.drewhamilton.poko.Poko
+
+@Suppress("Unused")
+@OptIn(ArrayContentSupport::class)
+@Poko class ArrayHolder(
+    @ArrayContentBased val stringArray: Array<String>,
+    @ArrayContentBased val nullableStringArray: Array<String>?,
+    @ArrayContentBased val booleanArray: BooleanArray,
+    @ArrayContentBased val nullableBooleanArray: BooleanArray?,
+    @ArrayContentBased val byteArray: ByteArray,
+    @ArrayContentBased val nullableByteArray: ByteArray?,
+    @ArrayContentBased val charArray: CharArray,
+    @ArrayContentBased val nullableCharArray: CharArray?,
+    @ArrayContentBased val shortArray: ShortArray,
+    @ArrayContentBased val nullableShortArray: ShortArray?,
+    @ArrayContentBased val intArray: IntArray,
+    @ArrayContentBased val nullableIntArray: IntArray?,
+    @ArrayContentBased val longArray: LongArray,
+    @ArrayContentBased val nullableLongArray: LongArray?,
+    @ArrayContentBased val floatArray: FloatArray,
+    @ArrayContentBased val nullableFloatArray: FloatArray?,
+    @ArrayContentBased val doubleArray: DoubleArray,
+    @ArrayContentBased val nullableDoubleArray: DoubleArray?,
+    @ArrayContentBased val nestedStringArray: Array<Array<String>>,
+    @ArrayContentBased val nestedIntArray: Array<IntArray>,
+)

--- a/poko-tests-without-k2/src/commonMain/kotlin/poko/Complex.kt
+++ b/poko-tests-without-k2/src/commonMain/kotlin/poko/Complex.kt
@@ -1,0 +1,24 @@
+package poko
+
+import dev.drewhamilton.poko.Poko
+
+@Suppress("Unused")
+@Poko class Complex<T>(
+    val referenceType: String,
+    val nullableReferenceType: String?,
+    val boolean: Boolean,
+    val nullableBoolean: Boolean?,
+    val int: Int,
+    val nullableInt: Int?,
+    val long: Long,
+    val float: Float,
+    val double: Double,
+    val arrayReferenceType: Array<String>,
+    val nullableArrayReferenceType: Array<String>?,
+    val arrayPrimitiveType: IntArray,
+    val nullableArrayPrimitiveType: IntArray?,
+    val genericCollectionType: List<T>,
+    val nullableGenericCollectionType: List<T>?,
+    val genericType: T,
+    val nullableGenericType: T?
+)

--- a/poko-tests-without-k2/src/commonMain/kotlin/poko/ComplexGenericArrayHolder.kt
+++ b/poko-tests-without-k2/src/commonMain/kotlin/poko/ComplexGenericArrayHolder.kt
@@ -1,0 +1,11 @@
+package poko
+
+import dev.drewhamilton.poko.ArrayContentBased
+import dev.drewhamilton.poko.ArrayContentSupport
+import dev.drewhamilton.poko.Poko
+
+@Suppress("Unused")
+@OptIn(ArrayContentSupport::class)
+@Poko class ComplexGenericArrayHolder<A : Any, G : A>(
+    @ArrayContentBased val generic: G,
+)

--- a/poko-tests-without-k2/src/commonMain/kotlin/poko/ExplicitDeclarations.kt
+++ b/poko-tests-without-k2/src/commonMain/kotlin/poko/ExplicitDeclarations.kt
@@ -1,0 +1,11 @@
+package poko
+
+import dev.drewhamilton.poko.Poko
+
+@Poko class ExplicitDeclarations(
+    private val string: String
+) {
+    override fun toString() = string
+    override fun equals(other: Any?) = other is ExplicitDeclarations && other.string.length == string.length
+    override fun hashCode() = string.length
+}

--- a/poko-tests-without-k2/src/commonMain/kotlin/poko/GenericArrayHolder.kt
+++ b/poko-tests-without-k2/src/commonMain/kotlin/poko/GenericArrayHolder.kt
@@ -1,0 +1,11 @@
+package poko
+
+import dev.drewhamilton.poko.ArrayContentBased
+import dev.drewhamilton.poko.ArrayContentSupport
+import dev.drewhamilton.poko.Poko
+
+@Suppress("Unused")
+@OptIn(ArrayContentSupport::class)
+@Poko class GenericArrayHolder<G>(
+    @ArrayContentBased val generic: G,
+)

--- a/poko-tests-without-k2/src/commonMain/kotlin/poko/Nested.kt
+++ b/poko-tests-without-k2/src/commonMain/kotlin/poko/Nested.kt
@@ -1,0 +1,9 @@
+package poko
+
+import dev.drewhamilton.poko.Poko
+
+class OuterClass {
+    @Poko class Nested(
+        val value: String
+    )
+}

--- a/poko-tests-without-k2/src/commonMain/kotlin/poko/Simple.kt
+++ b/poko-tests-without-k2/src/commonMain/kotlin/poko/Simple.kt
@@ -1,0 +1,10 @@
+package poko
+
+import dev.drewhamilton.poko.Poko
+
+@Suppress("Unused")
+@Poko class Simple(
+    val int: Int,
+    val requiredString: String,
+    val optionalString: String?
+)

--- a/poko-tests-without-k2/src/commonMain/kotlin/poko/SimpleWithExtraParam.kt
+++ b/poko-tests-without-k2/src/commonMain/kotlin/poko/SimpleWithExtraParam.kt
@@ -1,0 +1,14 @@
+package poko
+
+import dev.drewhamilton.poko.Poko
+
+@Suppress("Unused")
+@Poko class SimpleWithExtraParam(
+    val int: Int,
+    val requiredString: String,
+    val optionalString: String?,
+    callback: (Unit) -> Boolean,
+) {
+    @Suppress("CanBePrimaryConstructorProperty")
+    val callback: (Unit) -> Boolean = callback
+}

--- a/poko-tests-without-k2/src/commonMain/kotlin/poko/SuperclassDeclarations.kt
+++ b/poko-tests-without-k2/src/commonMain/kotlin/poko/SuperclassDeclarations.kt
@@ -1,0 +1,8 @@
+package poko
+
+import Super
+import dev.drewhamilton.poko.Poko
+
+@Poko class SuperclassDeclarations(
+    val number: Number
+) : Super()

--- a/poko-tests-without-k2/src/commonTest/kotlin/AnyArrayHolderTest.kt
+++ b/poko-tests-without-k2/src/commonTest/kotlin/AnyArrayHolderTest.kt
@@ -1,0 +1,295 @@
+
+import assertk.all
+import assertk.assertAll
+import assertk.assertThat
+import assertk.assertions.hashCodeFun
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEqualTo
+import assertk.assertions.toStringFun
+import kotlin.test.Test
+import data.AnyArrayHolder as AnyArrayHolderData
+import poko.AnyArrayHolder as AnyArrayHolderPoko
+
+class AnyArrayHolderTest {
+    @Test fun two_AnyArrayHolder_instances_holding_equivalent_typed_arrays_match() {
+        val a = AnyArrayHolderPoko(
+            any = arrayOf("string A", "string B"),
+            nullableAny = null,
+            trailingProperty = "trailing string",
+        )
+        val b = AnyArrayHolderPoko(
+            any = arrayOf("string A", "string B"),
+            nullableAny = null,
+            trailingProperty = "trailing string",
+        )
+        assertAll {
+            assertThat(a).isEqualTo(b)
+            assertThat(b).isEqualTo(a)
+
+            assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
+            assertThat(a).toStringFun().isEqualTo(b.toString())
+        }
+    }
+
+    @Test fun two_AnyArrayHolder_instances_holding_equivalent_nested_typed_arrays_match() {
+        val a = AnyArrayHolderPoko(
+            any = arrayOf(arrayOf("xx", "xy"), arrayOf("yx", "yy")),
+            nullableAny = arrayOf(arrayOf(1L, 2f), arrayOf(3.0, 4)),
+            trailingProperty = "trailing string",
+        )
+        val b = AnyArrayHolderPoko(
+            any = arrayOf(arrayOf("xx", "xy"), arrayOf("yx", "yy")),
+            nullableAny = arrayOf(arrayOf(1L, 2f), arrayOf(3.0, 4)),
+            trailingProperty = "trailing string",
+        )
+        assertAll {
+            assertThat(a).isEqualTo(b)
+            assertThat(b).isEqualTo(a)
+
+            assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
+            assertThat(a).toStringFun().isEqualTo(b.toString())
+        }
+    }
+
+    @Test fun two_AnyArrayHolder_instances_holding_equivalent_boolean_arrays_match() {
+        val a = AnyArrayHolderPoko(
+            any = booleanArrayOf(false, true, true),
+            nullableAny = null,
+            trailingProperty = "trailing string",
+        )
+        val b = AnyArrayHolderPoko(
+            any = booleanArrayOf(false, true, true),
+            nullableAny = null,
+            trailingProperty = "trailing string",
+        )
+        assertAll {
+            assertThat(a).isEqualTo(b)
+            assertThat(b).isEqualTo(a)
+
+            assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
+            assertThat(a).toStringFun().isEqualTo(b.toString())
+        }
+    }
+
+    @Test fun two_AnyArrayHolder_instances_holding_equivalent_byte_arrays_match() {
+        val a = AnyArrayHolderPoko(
+            any = byteArrayOf(Byte.MIN_VALUE, Byte.MAX_VALUE),
+            nullableAny = null,
+            trailingProperty = "trailing string",
+        )
+        val b = AnyArrayHolderPoko(
+            any = byteArrayOf(Byte.MIN_VALUE, Byte.MAX_VALUE),
+            nullableAny = null,
+            trailingProperty = "trailing string",
+        )
+        assertAll {
+            assertThat(a).isEqualTo(b)
+            assertThat(b).isEqualTo(a)
+
+            assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
+            assertThat(a).toStringFun().isEqualTo(b.toString())
+        }
+    }
+
+    @Test fun two_AnyArrayHolder_instances_holding_equivalent_char_arrays_match() {
+        val a = AnyArrayHolderPoko(
+            any = charArrayOf('m', 'n', 'o', 'P'),
+            nullableAny = null,
+            trailingProperty = "trailing string",
+        )
+        val b = AnyArrayHolderPoko(
+            any = charArrayOf('m', 'n', 'o', 'P'),
+            nullableAny = null,
+            trailingProperty = "trailing string",
+        )
+        assertAll {
+            assertThat(a).isEqualTo(b)
+            assertThat(b).isEqualTo(a)
+
+            assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
+            assertThat(a).toStringFun().isEqualTo(b.toString())
+        }
+    }
+
+    @Test fun two_AnyArrayHolder_instances_holding_equivalent_short_arrays_match() {
+        val a = AnyArrayHolderPoko(
+            any = shortArrayOf(6556.toShort()),
+            nullableAny = null,
+            trailingProperty = "trailing string",
+        )
+        val b = AnyArrayHolderPoko(
+            any = shortArrayOf(6556.toShort()),
+            nullableAny = null,
+            trailingProperty = "trailing string",
+        )
+        assertAll {
+            assertThat(a).isEqualTo(b)
+            assertThat(b).isEqualTo(a)
+
+            assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
+            assertThat(a).toStringFun().isEqualTo(b.toString())
+        }
+    }
+
+    @Test fun two_AnyArrayHolder_instances_holding_equivalent_int_arrays_match() {
+        val a = AnyArrayHolderPoko(
+            any = intArrayOf(6556),
+            nullableAny = null,
+            trailingProperty = "trailing string",
+        )
+        val b = AnyArrayHolderPoko(
+            any = intArrayOf(6556),
+            nullableAny = null,
+            trailingProperty = "trailing string",
+        )
+        assertAll {
+            assertThat(a).isEqualTo(b)
+            assertThat(b).isEqualTo(a)
+
+            assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
+            assertThat(a).toStringFun().isEqualTo(b.toString())
+        }
+    }
+
+    @Test fun two_AnyArrayHolder_instances_holding_equivalent_long_arrays_match() {
+        val a = AnyArrayHolderPoko(
+            any = longArrayOf(987654321L, 1234567890L),
+            nullableAny = null,
+            trailingProperty = "trailing string",
+        )
+        val b = AnyArrayHolderPoko(
+            any = longArrayOf(987654321L, 1234567890L),
+            nullableAny = null,
+            trailingProperty = "trailing string",
+        )
+        assertAll {
+            assertThat(a).isEqualTo(b)
+            assertThat(b).isEqualTo(a)
+
+            assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
+            assertThat(a).toStringFun().isEqualTo(b.toString())
+        }
+    }
+
+    @Test fun two_AnyArrayHolder_instances_holding_equivalent_float_arrays_match() {
+        val a = AnyArrayHolderPoko(
+            any = floatArrayOf(1.2f, 2.3f, 3.4f),
+            nullableAny = null,
+            trailingProperty = "trailing string",
+        )
+        val b = AnyArrayHolderPoko(
+            any = floatArrayOf(1.2f, 2.3f, 3.4f),
+            nullableAny = null,
+            trailingProperty = "trailing string",
+        )
+        assertAll {
+            assertThat(a).isEqualTo(b)
+            assertThat(b).isEqualTo(a)
+
+            assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
+            assertThat(a).toStringFun().isEqualTo(b.toString())
+        }
+    }
+
+    @Test fun two_AnyArrayHolder_instances_holding_equivalent_double_arrays_match() {
+        val a = AnyArrayHolderPoko(
+            any = doubleArrayOf(0.0, -0.0, Double.NaN),
+            nullableAny = null,
+            trailingProperty = "trailing string",
+        )
+        val b = AnyArrayHolderPoko(
+            any = doubleArrayOf(0.0, -0.0, Double.NaN),
+            nullableAny = null,
+            trailingProperty = "trailing string",
+        )
+        assertAll {
+            assertThat(a).isEqualTo(b)
+            assertThat(b).isEqualTo(a)
+
+            assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
+            assertThat(a).toStringFun().isEqualTo(b.toString())
+        }
+    }
+
+    @Test fun two_AnyArrayHolder_instances_holding_equivalent_nonarrays_match() {
+        val a = AnyArrayHolderPoko(
+            any = listOf("one", "two"),
+            nullableAny = null,
+            trailingProperty = "trailing string",
+        )
+        val b = AnyArrayHolderPoko(
+            any = listOf("one", "two"),
+            nullableAny = null,
+            trailingProperty = "trailing string",
+        )
+        assertAll {
+            assertThat(a).isEqualTo(b)
+            assertThat(b).isEqualTo(a)
+
+            assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
+            assertThat(a).toStringFun().isEqualTo(b.toString())
+        }
+    }
+
+    @Test fun two_AnyArrayHolder_instances_holding_inequivalent_typed_arrays_are_not_equals() {
+        val a = AnyArrayHolderPoko(
+            any = arrayOf(arrayOf("xx", "xy"), arrayOf("yx", "yy")),
+            nullableAny = null,
+            trailingProperty = "trailing string",
+        )
+        val b = AnyArrayHolderPoko(
+            any = arrayOf(arrayOf(1L, 2f), arrayOf(3.0, 4)),
+            nullableAny = null,
+            trailingProperty = "trailing string",
+        )
+        assertThat(a).isNotEqualTo(b)
+        assertThat(b).isNotEqualTo(a)
+    }
+
+    @Test fun AnyArrayHolder_instances_holding_mismatching_types_are_not_equals() {
+        val a = AnyArrayHolderPoko(
+            any = arrayOf("x", "y"),
+            nullableAny = null,
+            trailingProperty = "trailing string",
+        )
+        val b = AnyArrayHolderPoko(
+            any = "xy",
+            nullableAny = null,
+            trailingProperty = "trailing string",
+        )
+        assertThat(a).isNotEqualTo(b)
+        assertThat(b).isNotEqualTo(a)
+    }
+
+    @Test fun AnyArrayHolder_instances_holding_trailing_properties_are_not_equals() {
+        val a = AnyArrayHolderPoko(
+            any = arrayOf("string A", "string B"),
+            nullableAny = null,
+            trailingProperty = "1",
+        )
+        val b = AnyArrayHolderPoko(
+            any = arrayOf("string A", "string B"),
+            nullableAny = null,
+            trailingProperty = "2",
+        )
+        assertThat(a).isNotEqualTo(b)
+        assertThat(b).isNotEqualTo(a)
+    }
+
+    @Test fun AnyArrayHolder_has_same_behavior_as_handwritten_implementation() {
+        val poko = AnyArrayHolderPoko(
+            any = arrayOf(1, 2L, 3f, 4.0),
+            nullableAny = arrayOf(1, 2L, 3f, 4.0),
+            trailingProperty = "trailing",
+        )
+        val data = AnyArrayHolderData(
+            any = arrayOf(1, 2L, 3f, 4.0),
+            nullableAny = arrayOf(1, 2L, 3f, 4.0),
+            trailingProperty = "trailing",
+        )
+        assertThat(poko).all {
+            hashCodeFun().isEqualTo(data.hashCode())
+            toStringFun().isEqualTo(data.toString())
+        }
+    }
+}

--- a/poko-tests-without-k2/src/commonTest/kotlin/ArrayHolderTest.kt
+++ b/poko-tests-without-k2/src/commonTest/kotlin/ArrayHolderTest.kt
@@ -1,0 +1,168 @@
+import assertk.assertAll
+import assertk.assertThat
+import assertk.assertions.hashCodeFun
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEqualTo
+import assertk.assertions.toStringFun
+import kotlin.test.Test
+import poko.ArrayHolder
+
+class ArrayHolderTest {
+    @Test fun two_equivalent_compiled_ArrayHolder_instances_match() {
+        val a = ArrayHolder(
+            stringArray = arrayOf("one string", "another string"),
+            nullableStringArray = null,
+            booleanArray = booleanArrayOf(true, false),
+            nullableBooleanArray = null,
+            byteArray = byteArrayOf(1.toByte(), 2.toByte()),
+            nullableByteArray = null,
+            charArray = charArrayOf('a', 'b', 'c', 'c'),
+            nullableCharArray = null,
+            shortArray = shortArrayOf(99.toShort(), 88.toShort()),
+            nullableShortArray = null,
+            intArray = intArrayOf(3, 4, 5),
+            nullableIntArray = null,
+            longArray = longArrayOf(98765L, 43210L),
+            nullableLongArray = null,
+            floatArray = floatArrayOf(3.14f, 1519f),
+            nullableFloatArray = null,
+            doubleArray = doubleArrayOf(2.22222, Double.NaN),
+            nullableDoubleArray = null,
+            nestedStringArray = arrayOf(
+                arrayOf("1A", "2A"),
+                arrayOf("1B", "2B", "3B"),
+            ),
+            nestedIntArray = arrayOf(
+                intArrayOf(1, 2, 3, 4),
+                intArrayOf(99, 98, 97),
+            ),
+        )
+        val b = ArrayHolder(
+            stringArray = arrayOf("one string", "another string"),
+            nullableStringArray = null,
+            booleanArray = booleanArrayOf(true, false),
+            nullableBooleanArray = null,
+            byteArray = byteArrayOf(1.toByte(), 2.toByte()),
+            nullableByteArray = null,
+            charArray = charArrayOf('a', 'b', 'c', 'c'),
+            nullableCharArray = null,
+            shortArray = shortArrayOf(99.toShort(), 88.toShort()),
+            nullableShortArray = null,
+            intArray = intArrayOf(3, 4, 5),
+            nullableIntArray = null,
+            longArray = longArrayOf(98765L, 43210L),
+            nullableLongArray = null,
+            floatArray = floatArrayOf(3.14f, 1519f),
+            nullableFloatArray = null,
+            doubleArray = doubleArrayOf(2.22222, Double.NaN),
+            nullableDoubleArray = null,
+            nestedStringArray = arrayOf(
+                arrayOf("1A", "2A"),
+                arrayOf("1B", "2B", "3B"),
+            ),
+            nestedIntArray = arrayOf(
+                intArrayOf(1, 2, 3, 4),
+                intArrayOf(99, 98, 97),
+            ),
+        )
+        assertAll {
+            assertThat(a).isEqualTo(b)
+            assertThat(b).isEqualTo(a)
+
+            assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
+            assertThat(a).toStringFun().isEqualTo(b.toString())
+        }
+    }
+
+    @Test fun two_inequivalent_compiled_ArrayHolder_instances_are_not_equals() {
+        val a = ArrayHolder(
+            stringArray = arrayOf("one string", "another string"),
+            nullableStringArray = null,
+            booleanArray = booleanArrayOf(true, false),
+            nullableBooleanArray = null,
+            byteArray = byteArrayOf(1.toByte(), 2.toByte()),
+            nullableByteArray = null,
+            charArray = charArrayOf('a', 'b', 'c', 'c'),
+            nullableCharArray = null,
+            shortArray = shortArrayOf(99.toShort(), 88.toShort()),
+            nullableShortArray = null,
+            intArray = intArrayOf(3, 4, 5),
+            nullableIntArray = null,
+            longArray = longArrayOf(98765L, 43210L),
+            nullableLongArray = null,
+            floatArray = floatArrayOf(3.14f, 1519f),
+            nullableFloatArray = null,
+            doubleArray = doubleArrayOf(2.22222, Double.NaN),
+            nullableDoubleArray = null,
+            nestedStringArray = arrayOf(
+                arrayOf("1A", "2A"),
+                arrayOf("1B", "2B", "3B"),
+            ),
+            nestedIntArray = arrayOf(
+                intArrayOf(1, 2, 3, 4),
+                intArrayOf(99, 98, 97),
+            ),
+        )
+        val b = ArrayHolder(
+            stringArray = arrayOf("just one string"), // <-- Different from a
+            nullableStringArray = null,
+            booleanArray = booleanArrayOf(true, false),
+            nullableBooleanArray = null,
+            byteArray = byteArrayOf(1.toByte(), 2.toByte()),
+            nullableByteArray = null,
+            charArray = charArrayOf('a', 'b', 'c', 'c'),
+            nullableCharArray = null,
+            shortArray = shortArrayOf(99.toShort(), 88.toShort()),
+            nullableShortArray = null,
+            intArray = intArrayOf(3, 4, 5),
+            nullableIntArray = null,
+            longArray = longArrayOf(98765L, 43210L),
+            nullableLongArray = null,
+            floatArray = floatArrayOf(3.14f, 1519f),
+            nullableFloatArray = null,
+            doubleArray = doubleArrayOf(2.22222, Double.NaN),
+            nullableDoubleArray = null,
+            nestedStringArray = arrayOf(
+                arrayOf("1A", "2A"),
+                arrayOf("1B", "2B", "3B"),
+            ),
+            nestedIntArray = arrayOf(
+                intArrayOf(1, 2, 3, 4),
+                intArrayOf(99, 98, 97),
+            ),
+        )
+        assertThat(a).isNotEqualTo(b)
+        assertThat(b).isNotEqualTo(a)
+
+        val c = ArrayHolder(
+            stringArray = arrayOf("one string", "another string"),
+            nullableStringArray = null,
+            booleanArray = booleanArrayOf(true, false),
+            nullableBooleanArray = null,
+            byteArray = byteArrayOf(1.toByte(), 2.toByte()),
+            nullableByteArray = null,
+            charArray = charArrayOf('x', 'y', 'z'), // <-- Different from a
+            nullableCharArray = null,
+            shortArray = shortArrayOf(99.toShort(), 88.toShort()),
+            nullableShortArray = null,
+            intArray = intArrayOf(3, 4, 5),
+            nullableIntArray = null,
+            longArray = longArrayOf(98765L, 43210L),
+            nullableLongArray = null,
+            floatArray = floatArrayOf(3.14f, 1519f),
+            nullableFloatArray = null,
+            doubleArray = doubleArrayOf(2.22222, Double.NaN),
+            nullableDoubleArray = null,
+            nestedStringArray = arrayOf(
+                arrayOf("1A", "2A"),
+                arrayOf("1B", "2B", "3B"),
+            ),
+            nestedIntArray = arrayOf(
+                intArrayOf(1, 2, 3, 4),
+                intArrayOf(99, 98, 97),
+            ),
+        )
+        assertThat(a).isNotEqualTo(c)
+        assertThat(c).isNotEqualTo(a)
+    }
+}

--- a/poko-tests-without-k2/src/commonTest/kotlin/ComplexGenericArrayHolderTest.kt
+++ b/poko-tests-without-k2/src/commonTest/kotlin/ComplexGenericArrayHolderTest.kt
@@ -1,0 +1,17 @@
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import poko.ComplexGenericArrayHolder
+
+class ComplexGenericArrayHolderTest {
+    @Test fun two_ComplexGenericArrayHolder_instances_with_equivalent_int_arrays_are_equals() {
+        val a = ComplexGenericArrayHolder(
+            generic = intArrayOf(50, 100),
+        )
+        val b = ComplexGenericArrayHolder(
+            generic = intArrayOf(50, 100),
+        )
+        assertThat(a).isEqualTo(b)
+        assertThat(b).isEqualTo(a)
+    }
+}

--- a/poko-tests-without-k2/src/commonTest/kotlin/ComplexTest.kt
+++ b/poko-tests-without-k2/src/commonTest/kotlin/ComplexTest.kt
@@ -1,0 +1,164 @@
+import assertk.all
+import assertk.assertAll
+import assertk.assertThat
+import assertk.assertions.hashCodeFun
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEqualTo
+import assertk.assertions.toStringFun
+import kotlin.test.Test
+import data.Complex as ComplexData
+import poko.Complex as ComplexPoko
+
+class ComplexTest {
+    @Test fun two_equivalent_compiled_Complex_instances_match() {
+        val arrayReferenceType = arrayOf("one string", "another string")
+        val arrayPrimitiveType = intArrayOf(3, 4, 5)
+        val a = ComplexPoko(
+            referenceType = "Text",
+            nullableReferenceType = null,
+            boolean = true,
+            nullableBoolean = null,
+            int = 2,
+            nullableInt = null,
+            long = 12345L,
+            float = 67f,
+            double = 89.0,
+            arrayReferenceType = arrayReferenceType,
+            nullableArrayReferenceType = null,
+            arrayPrimitiveType = arrayPrimitiveType,
+            nullableArrayPrimitiveType = null,
+            genericCollectionType = listOf(4, 6, 8).map { EvenInt(it) },
+            nullableGenericCollectionType = null,
+            genericType = EvenInt(2),
+            nullableGenericType = null,
+        )
+        val b = ComplexPoko(
+            referenceType = "Text",
+            nullableReferenceType = null,
+            boolean = true,
+            nullableBoolean = null,
+            int = 2,
+            nullableInt = null,
+            long = 12345L,
+            float = 67f,
+            double = 89.0,
+            arrayReferenceType = arrayReferenceType,
+            nullableArrayReferenceType = null,
+            arrayPrimitiveType = arrayPrimitiveType,
+            nullableArrayPrimitiveType = null,
+            genericCollectionType = listOf(4, 6, 8).map { EvenInt(it) },
+            nullableGenericCollectionType = null,
+            genericType = EvenInt(2),
+            nullableGenericType = null,
+        )
+        assertAll {
+            assertThat(a).isEqualTo(b)
+            assertThat(b).isEqualTo(a)
+
+            assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
+            assertThat(a).toStringFun().isEqualTo(b.toString())
+        }
+    }
+
+    @Test fun two_inequivalent_compiled_Complex_instances_are_not_equals() {
+        val arrayReferenceType = arrayOf("one string", "another string")
+        val arrayPrimitiveType = intArrayOf(3, 4, 5)
+        val a = ComplexPoko(
+            referenceType = "Text",
+            nullableReferenceType = null,
+            boolean = true,
+            nullableBoolean = null,
+            int = 2,
+            nullableInt = null,
+            long = 12345L,
+            float = 67f,
+            double = 89.0,
+            arrayReferenceType = arrayReferenceType,
+            nullableArrayReferenceType = null,
+            arrayPrimitiveType = arrayPrimitiveType,
+            nullableArrayPrimitiveType = null,
+            genericCollectionType = listOf(4, 6, 8).map { EvenInt(it) },
+            nullableGenericCollectionType = null,
+            genericType = EvenInt(2),
+            nullableGenericType = null,
+        )
+        val b = ComplexPoko(
+            referenceType = "Text",
+            nullableReferenceType = "non-null",
+            boolean = true,
+            nullableBoolean = null,
+            int = 2,
+            nullableInt = null,
+            long = 12345L,
+            float = 67f,
+            double = 89.0,
+            arrayReferenceType = arrayReferenceType,
+            nullableArrayReferenceType = null,
+            arrayPrimitiveType = arrayPrimitiveType,
+            nullableArrayPrimitiveType = null,
+            genericCollectionType = listOf(4, 6, 8).map { EvenInt(it) },
+            nullableGenericCollectionType = null,
+            genericType = EvenInt(2),
+            nullableGenericType = null,
+        )
+        assertThat(a).isNotEqualTo(b)
+        assertThat(b).isNotEqualTo(a)
+    }
+
+    @Test fun compiled_Complex_class_instance_has_expected_hashCode_and_toString() {
+        val arrayReferenceType = arrayOf("one string", "another string")
+        val arrayPrimitiveType = intArrayOf(3, 4, 5)
+        val poko = ComplexPoko(
+            referenceType = "Text",
+            nullableReferenceType = null,
+            boolean = true,
+            nullableBoolean = null,
+            int = 2,
+            nullableInt = null,
+            long = 12345L,
+            float = 67f,
+            double = 89.0,
+            arrayReferenceType = arrayReferenceType,
+            nullableArrayReferenceType = null,
+            arrayPrimitiveType = arrayPrimitiveType,
+            nullableArrayPrimitiveType = null,
+            genericCollectionType = listOf(4, 6, 8).map { EvenInt(it) },
+            nullableGenericCollectionType = null,
+            genericType = EvenInt(2),
+            nullableGenericType = null,
+        )
+        val data = ComplexData(
+            referenceType = "Text",
+            nullableReferenceType = null,
+            boolean = true,
+            nullableBoolean = null,
+            int = 2,
+            nullableInt = null,
+            long = 12345L,
+            float = 67f,
+            double = 89.0,
+            arrayReferenceType = arrayReferenceType,
+            nullableArrayReferenceType = null,
+            arrayPrimitiveType = arrayPrimitiveType,
+            nullableArrayPrimitiveType = null,
+            genericCollectionType = listOf(4, 6, 8).map { EvenInt(it) },
+            nullableGenericCollectionType = null,
+            genericType = EvenInt(2),
+            nullableGenericType = null,
+        )
+        assertThat(poko).all {
+            hashCodeFun().isEqualTo(data.hashCode())
+            toStringFun().isEqualTo(data.toString())
+        }
+    }
+
+    data class EvenInt(private val value: Int) : Number() {
+        init { check(value % 2 == 0) }
+        override fun toByte() = value.toByte()
+        override fun toDouble() = value.toDouble()
+        override fun toFloat() = value.toFloat()
+        override fun toInt() = value
+        override fun toLong() = value.toLong()
+        override fun toShort() = value.toShort()
+    }
+}

--- a/poko-tests-without-k2/src/commonTest/kotlin/ExplicitDeclarationsTest.kt
+++ b/poko-tests-without-k2/src/commonTest/kotlin/ExplicitDeclarationsTest.kt
@@ -1,0 +1,42 @@
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.hashCodeFun
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEqualTo
+import assertk.assertions.toStringFun
+import kotlin.test.Test
+import data.ExplicitDeclarations as ExplicitDeclarationsData
+import poko.ExplicitDeclarations as ExplicitDeclarationsPoko
+
+class ExplicitDeclarationsTest {
+    @Test fun two_equivalent_compiled_ExplicitDeclarations_instances_are_equals() {
+        val a = ExplicitDeclarationsPoko("string 1")
+        val b = ExplicitDeclarationsPoko("string 2")
+        assertThat(a).isEqualTo(b)
+        assertThat(b).isEqualTo(a)
+    }
+
+    @Test fun two_inequivalent_compiled_ExplicitDeclarations_instances_are_not_equals() {
+        val a = ExplicitDeclarationsPoko("string 1")
+        val b = ExplicitDeclarationsPoko("string 11")
+        assertThat(a).isNotEqualTo(b)
+        assertThat(b).isNotEqualTo(a)
+    }
+
+    @Test fun compilation_with_explicit_function_declarations_respects_explicit_hashCode() {
+        val testString = "test string"
+        val poko = ExplicitDeclarationsPoko(testString)
+        val data = ExplicitDeclarationsData(testString)
+
+        assertThat(poko).all {
+            hashCodeFun().all {
+                isEqualTo(testString.length)
+                isEqualTo(data.hashCode())
+            }
+            toStringFun().all {
+                isEqualTo(testString)
+                isEqualTo(data.toString())
+            }
+        }
+    }
+}

--- a/poko-tests-without-k2/src/commonTest/kotlin/GenericArrayHolderTest.kt
+++ b/poko-tests-without-k2/src/commonTest/kotlin/GenericArrayHolderTest.kt
@@ -1,0 +1,50 @@
+import assertk.assertThat
+import assertk.assertions.hashCodeFun
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEqualTo
+import assertk.assertions.toStringFun
+import kotlin.test.Test
+import poko.GenericArrayHolder
+
+class GenericArrayHolderTest {
+    @Test fun two_GenericArrayHolder_instances_with_equivalent_typed_arrays_are_equals() {
+        val a = GenericArrayHolder(arrayOf(arrayOf("5%, 10%"), intArrayOf(5, 10), booleanArrayOf(false, true)))
+        val b = GenericArrayHolder(arrayOf(arrayOf("5%, 10%"), intArrayOf(5, 10), booleanArrayOf(false, true)))
+        assertThat(a).isEqualTo(b)
+        assertThat(b).isEqualTo(a)
+        assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
+        assertThat(a).toStringFun().isEqualTo(b.toString())
+    }
+
+    @Test fun two_GenericArrayHolder_instances_with_equivalent_int_arrays_are_equals() {
+        val a = GenericArrayHolder(intArrayOf(5, 10))
+        val b = GenericArrayHolder(intArrayOf(5, 10))
+        assertThat(a).isEqualTo(b)
+        assertThat(b).isEqualTo(a)
+        assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
+        assertThat(a).toStringFun().isEqualTo(b.toString())
+    }
+
+    @Test fun two_GenericArrayHolder_instances_with_equivalent_nonarrays_are_equals() {
+        val a = GenericArrayHolder("5, 10")
+        val b = GenericArrayHolder("5, 10")
+        assertThat(a).isEqualTo(b)
+        assertThat(b).isEqualTo(a)
+        assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
+        assertThat(a).toStringFun().isEqualTo(b.toString())
+    }
+
+    @Test fun two_GenericArrayHolder_instances_holding_inequivalent_long_arrays_are_not_equals() {
+        val a = GenericArrayHolder(longArrayOf(Long.MIN_VALUE))
+        val b = GenericArrayHolder(longArrayOf(Long.MAX_VALUE))
+        assertThat(a).isNotEqualTo(b)
+        assertThat(b).isNotEqualTo(a)
+    }
+
+    @Test fun two_GenericArrayHolder_instances_holding_mismatching_types_are_not_equals() {
+        val a = GenericArrayHolder(arrayOf("x", "y"))
+        val b = GenericArrayHolder("xy")
+        assertThat(a).isNotEqualTo(b)
+        assertThat(b).isNotEqualTo(a)
+    }
+}

--- a/poko-tests-without-k2/src/commonTest/kotlin/NestedTest.kt
+++ b/poko-tests-without-k2/src/commonTest/kotlin/NestedTest.kt
@@ -1,0 +1,34 @@
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.hashCodeFun
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEqualTo
+import assertk.assertions.toStringFun
+import kotlin.test.Test
+import data.OuterClass.Nested as NestedData
+import poko.OuterClass.Nested as NestedPoko
+
+class NestedTest {
+    @Test fun two_equivalent_compiled_Nested_instances_are_equals() {
+        val a = NestedPoko("string 1")
+        val b = NestedPoko("string 1")
+        assertThat(a).isEqualTo(b)
+        assertThat(b).isEqualTo(a)
+    }
+
+    @Test fun two_inequivalent_compiled_Nested_instances_are_not_equals() {
+        val a = NestedPoko("string 1")
+        val b = NestedPoko("string 2")
+        assertThat(a).isNotEqualTo(b)
+        assertThat(b).isNotEqualTo(a)
+    }
+
+    @Test fun compilation_of_nested_class_within_class_matches_corresponding_data_class_hashCode() {
+        val poko = NestedPoko("nested class value")
+        val data = NestedData("nested class value")
+        assertThat(poko).all {
+            hashCodeFun().isEqualTo(data.hashCode())
+            toStringFun().isEqualTo(data.toString())
+        }
+    }
+}

--- a/poko-tests-without-k2/src/commonTest/kotlin/SimpleTest.kt
+++ b/poko-tests-without-k2/src/commonTest/kotlin/SimpleTest.kt
@@ -1,0 +1,34 @@
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.hashCodeFun
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEqualTo
+import assertk.assertions.toStringFun
+import kotlin.test.Test
+import data.Simple as SimpleData
+import poko.Simple as SimplePoko
+
+class SimpleTest {
+    @Test fun two_equivalent_compiled_Simple_instances_are_equals() {
+        val a = SimplePoko(1, "String", null)
+        val b = SimplePoko(1, "String", null)
+        assertThat(a).isEqualTo(b)
+        assertThat(b).isEqualTo(a)
+    }
+
+    @Test fun two_inequivalent_compiled_Simple_instances_are_not_equals() {
+        val a = SimplePoko(1, "String", null)
+        val b = SimplePoko(1, "String", "non-null")
+        assertThat(a).isNotEqualTo(b)
+        assertThat(b).isNotEqualTo(a)
+    }
+
+    @Test fun compiled_Simple_class_instance_has_expected_hashCode() {
+        val poko = SimplePoko(1, "String", null)
+        val data = SimpleData(1, "String", null)
+        assertThat(poko).all {
+            hashCodeFun().isEqualTo(data.hashCode())
+            toStringFun().isEqualTo(data.toString())
+        }
+    }
+}

--- a/poko-tests-without-k2/src/commonTest/kotlin/SimpleWithExtraParamTest.kt
+++ b/poko-tests-without-k2/src/commonTest/kotlin/SimpleWithExtraParamTest.kt
@@ -1,0 +1,17 @@
+import assertk.assertThat
+import assertk.assertions.hashCodeFun
+import assertk.assertions.isEqualTo
+import assertk.assertions.toStringFun
+import kotlin.test.Test
+import poko.SimpleWithExtraParam
+
+class SimpleWithExtraParamTest {
+    @Test fun nonproperty_parameter_is_ignored_for_equals() {
+        val a = SimpleWithExtraParam(1, "String", null, { true })
+        val b = SimpleWithExtraParam(1, "String", null, { false })
+        assertThat(a).isEqualTo(b)
+        assertThat(b).isEqualTo(a)
+        assertThat(a).hashCodeFun().isEqualTo(b.hashCode())
+        assertThat(a).toStringFun().isEqualTo(b.toString())
+    }
+}

--- a/poko-tests-without-k2/src/commonTest/kotlin/SuperclassDeclarationsTest.kt
+++ b/poko-tests-without-k2/src/commonTest/kotlin/SuperclassDeclarationsTest.kt
@@ -1,0 +1,49 @@
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.hashCodeFun
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEqualTo
+import assertk.assertions.toStringFun
+import kotlin.test.Test
+import data.SuperclassDeclarations as SuperclassDeclarationsData
+import poko.SuperclassDeclarations as SuperclassDeclarationsPoko
+
+class SuperclassDeclarationsTest {
+    @Test fun two_equivalent_compiled_Subclass_instances_are_equals() {
+        val a = SuperclassDeclarationsPoko(999.9)
+        val b = SuperclassDeclarationsPoko(999.9)
+
+        // Super class equals implementation returns `other == true`; this confirms that is overridden:
+        assertThat(a).isNotEqualTo(true)
+        assertThat(b).isNotEqualTo(true)
+
+        assertThat(a).isEqualTo(b)
+        assertThat(b).isEqualTo(a)
+    }
+
+    @Test fun two_inequivalent_compiled_Subclass_instances_are_not_equals() {
+        val a = SuperclassDeclarationsPoko(999.9)
+        val b = SuperclassDeclarationsPoko(888.8)
+        // Super class equals implementation returns `other == true`; this confirms that is overridden:
+        assertThat(a).isNotEqualTo(true)
+        assertThat(b).isNotEqualTo(true)
+
+        assertThat(a).isNotEqualTo(b)
+        assertThat(b).isNotEqualTo(a)
+    }
+
+    @Test fun superclass_hashCode_is_overridden() {
+        val poko = SuperclassDeclarationsPoko(123.4)
+        val data = SuperclassDeclarationsData(123.4)
+        assertThat(poko).all {
+            hashCodeFun().all {
+                isEqualTo(data.hashCode())
+                isNotEqualTo(50934)
+            }
+            toStringFun().all {
+                isEqualTo(data.toString())
+                isNotEqualTo("superclass")
+            }
+        }
+    }
+}

--- a/poko-tests/build.gradle.kts
+++ b/poko-tests/build.gradle.kts
@@ -1,7 +1,4 @@
-import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
-import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 import org.jetbrains.kotlin.gradle.plugin.NATIVE_COMPILER_PLUGIN_CLASSPATH_CONFIGURATION_NAME
-import org.jetbrains.kotlin.gradle.plugin.PLUGIN_CLASSPATH_CONFIGURATION_NAME
 
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
@@ -9,83 +6,47 @@ plugins {
 
 val jvmToolchainVersion: Int? = System.getenv()["poko_tests_jvm_toolchain_version"]?.toInt()
 
-fun <T : KotlinTarget> T.applyK2(): T {
-  compilations.configureEach {
-    compilerOptions.options.languageVersion.set(KotlinVersion.KOTLIN_2_0)
-  }
-
-  // Dummy value required to disambiguate these targets' configurations.
-  // See https://kotlinlang.org/docs/multiplatform-set-up-targets.html#distinguish-several-targets-for-one-platform
-  attributes.attribute(Attribute.of("com.example.useK2", Boolean::class.javaObjectType), true)
-
-  return this
-}
-
 kotlin {
   jvmToolchainVersion?.let { jvmToolchain(it) }
 
   jvm()
-  jvm("jvmK2").applyK2()
 
   js {
     nodejs()
     // Produce a JS file for performance tests.
     binaries.executable()
   }
-  js("jsK2").applyK2().nodejs()
 
   mingwX64()
-  mingwX64("mingwX64K2").applyK2()
 
   linuxArm64()
-  linuxArm64("linuxArm64K2").applyK2()
   linuxX64()
-  linuxX64("linuxX64K2").applyK2()
 
   iosArm64()
-  iosArm64("iosArm64K2").applyK2()
   iosSimulatorArm64()
-  iosSimulatorArm64("iosSimulatorArm64K2").applyK2()
   iosX64()
-  iosX64("iosX64K2").applyK2()
 
   macosArm64()
-  macosArm64("macosArm64K2").applyK2()
   macosX64()
-  macosX64("macosX64K2").applyK2()
 
   tvosArm64()
-  tvosArm64("tvosArm64K2").applyK2()
   tvosX64()
-  tvosX64("tvosX64K2").applyK2()
   tvosSimulatorArm64()
-  tvosSimulatorArm64("tvosSimulatorArm64K2").applyK2()
 
   wasmJs().nodejs()
-  wasmJs("wasmJsK2").applyK2().nodejs()
   wasmWasi().nodejs()
-  wasmWasi("wasmWasiK2").applyK2().nodejs()
 
   watchosArm32()
-  watchosArm32("watchosArm32K2").applyK2()
   watchosArm64()
-  watchosArm64("watchosArm64K2").applyK2()
   watchosDeviceArm64()
-  watchosDeviceArm64("watchosDeviceArm64K2").applyK2()
   watchosSimulatorArm64()
-  watchosSimulatorArm64("watchosSimulatorArm64K2").applyK2()
   watchosX64()
-  watchosX64("watchosX64K2").applyK2()
 
   androidNativeArm32()
-  androidNativeArm32("androidNativeArm32K2").applyK2()
   androidNativeArm64()
-  androidNativeArm64("androidNativeArm64K2").applyK2()
 
   androidNativeX86()
-  androidNativeX86("androidNativeX86K2").applyK2()
   androidNativeX64()
-  androidNativeX64("androidNativeX64K2").applyK2()
 
   sourceSets {
     commonMain {

--- a/poko-tests/build.gradle.kts
+++ b/poko-tests/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.kotlin.gradle.plugin.NATIVE_COMPILER_PLUGIN_CLASSPATH_CONFIGURATION_NAME
 import org.jetbrains.kotlin.gradle.plugin.PLUGIN_CLASSPATH_CONFIGURATION_NAME
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
@@ -34,7 +35,9 @@ kotlin {
   tvosX64()
   tvosSimulatorArm64()
 
+  @OptIn(ExperimentalWasmDsl::class)
   wasmJs().nodejs()
+  @OptIn(ExperimentalWasmDsl::class)
   wasmWasi().nodejs()
 
   watchosArm32()

--- a/sample/compose/build.gradle.kts
+++ b/sample/compose/build.gradle.kts
@@ -20,11 +20,6 @@ if (jvmToolchainLanguageVersion != null) {
     }
 }
 
-composeCompiler {
-    // https://youtrack.jetbrains.com/issue/KT-67216
-    suppressKotlinVersionCompatibilityCheck = libs.versions.kotlin
-}
-
 android {
     namespace = "dev.drewhamilton.poko.sample.compose"
     compileSdk = 33

--- a/sample/compose/build.gradle.kts
+++ b/sample/compose/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 poko {
-    pokoAnnotation.set("dev.drewhamilton.poko.sample.compose.Poko")
+    pokoAnnotation.set("dev/drewhamilton/poko/sample/compose/Poko")
 }
 
 if (jvmToolchainLanguageVersion != null) {

--- a/sample/compose/build.gradle.kts
+++ b/sample/compose/build.gradle.kts
@@ -4,6 +4,7 @@ import dev.drewhamilton.poko.sample.build.resolvedJavaVersion
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.compose.plugin)
     id("dev.drewhamilton.poko")
 }
 
@@ -17,6 +18,11 @@ if (jvmToolchainLanguageVersion != null) {
             languageVersion.set(jvmToolchainLanguageVersion)
         }
     }
+}
+
+composeCompiler {
+    // https://youtrack.jetbrains.com/issue/KT-67216
+    suppressKotlinVersionCompatibilityCheck = libs.versions.kotlin
 }
 
 android {
@@ -46,10 +52,6 @@ android {
         shaders = false
         androidResources = false
     }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.androidx.compose.compiler.get().version
-    }
 }
 
 dependencies {
@@ -61,8 +63,4 @@ dependencies {
 
 repositories {
     google()
-    if (android.composeOptions.kotlinCompilerExtensionVersion!!.contains("dev")) {
-        logger.lifecycle("Adding Compose compiler dev repository")
-        maven { url = uri("https://androidx.dev/storage/compose-compiler/repository") }
-    }
 }

--- a/sample/kotlin-js-store/yarn.lock
+++ b/sample/kotlin-js-store/yarn.lock
@@ -42,14 +42,6 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
-  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
-  dependencies:
-    balanced-match "^1.0.0"
-    concat-map "0.0.1"
-
 brace-expansion@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
@@ -122,11 +114,6 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
-concat-map@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
 debug@4.3.4:
   version "4.3.4"
@@ -207,17 +194,16 @@ glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob@7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
-  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
+glob@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
+  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
     inherits "2"
-    minimatch "^3.0.4"
+    minimatch "^5.0.1"
     once "^1.3.0"
-    path-is-absolute "^1.0.0"
 
 has-flag@^4.0.0:
   version "4.0.0"
@@ -310,17 +296,17 @@ minimatch@5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^3.0.4:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+minimatch@^5.0.1:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
+  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
   dependencies:
-    brace-expansion "^1.1.7"
+    brace-expansion "^2.0.1"
 
-mocha@10.2.0:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.2.0.tgz#1fd4a7c32ba5ac372e03a17eef435bd00e5c68b8"
-  integrity sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==
+mocha@10.3.0:
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.3.0.tgz#0e185c49e6dccf582035c05fa91084a4ff6e3fe9"
+  integrity sha512-uF2XJs+7xSLsrmIvn37i/wnc91nw7XjOQB8ccyx5aEgdnohr7n+rEiZP23WkCYHjilR6+EboEnbq/ZQDz4LSbg==
   dependencies:
     ansi-colors "4.1.1"
     browser-stdout "1.3.1"
@@ -329,13 +315,12 @@ mocha@10.2.0:
     diff "5.0.0"
     escape-string-regexp "4.0.0"
     find-up "5.0.0"
-    glob "7.2.0"
+    glob "8.1.0"
     he "1.2.0"
     js-yaml "4.1.0"
     log-symbols "4.1.0"
     minimatch "5.0.1"
     ms "2.1.3"
-    nanoid "3.3.3"
     serialize-javascript "6.0.0"
     strip-json-comments "3.1.1"
     supports-color "8.1.1"
@@ -353,11 +338,6 @@ ms@2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-
-nanoid@3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
-  integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
@@ -389,11 +369,6 @@ path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
-
-path-is-absolute@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
-  integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
 picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.3.1"
@@ -486,10 +461,10 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-typescript@5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
-  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+typescript@5.4.3:
+  version "5.4.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.3.tgz#5c6fedd4c87bee01cd7a528a30145521f8e0feff"
+  integrity sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==
 
 workerpool@6.2.1:
   version "6.2.1"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,4 +42,5 @@ include(
     ":poko-gradle-plugin",
     ":poko-tests",
     ":poko-tests:performance",
+    ":poko-tests-without-k2",
 )


### PR DESCRIPTION
Kotlin 2.0 enables the new K2 compiler by default, so non-K2 code paths can be removed.