### PR TITLE
Move Gradle wrapper validation to standalone Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
       - name: Install JDK
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/gradle-wrapper.yml
+++ b/.github/workflows/gradle-wrapper.yml
@@ -1,0 +1,17 @@
+name: 'Validate Gradle wrapper'
+
+on:
+  pull_request:
+    paths:
+      - 'gradlew'
+      - 'gradlew.bat'
+      - 'gradle/wrapper/'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - name: Validate
+        uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
As recommended by Jake in #260.

I guess the downside is that the new Action can't be used in a branch protection rule because it doesn't always run. Leaving the validation in `release.yml` out of an abundance of caution.