### PR TITLE
Change optional repository URL definitions

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.20" />
+    <option name="version" value="1.9.21" />
   </component>
 </project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,9 +26,10 @@ allprojects {
             logger.lifecycle("Adding snapshots repository for ${this@allprojects}")
             maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
         }
-        if (rootProject.property("kotlin_dev_version_enabled") == "true") {
-            logger.lifecycle("Adding Kotlin dev repository for ${this@allprojects}")
-            maven { url = uri("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev") }
+        val kotlinDevRepository = rootProject.findProperty("kotlin_dev_repository")
+        if (kotlinDevRepository != null) {
+            logger.lifecycle("Adding <$kotlinDevRepository> repository for ${this@allprojects}")
+            maven { url = uri(kotlinDevRepository) }
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,9 +22,10 @@ allprojects {
         // KSP:
         google()
 
-        if (rootProject.property("snapshot_dependencies_enabled") == "true") {
-            logger.lifecycle("Adding snapshots repository for ${this@allprojects}")
-            maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
+        val snapshotsRepository = rootProject.findProperty("snapshots_repository")
+        if (snapshotsRepository != null) {
+            logger.lifecycle("Adding <$snapshotsRepository> repository for ${this@allprojects}")
+            maven { url = uri(snapshotsRepository) }
         }
         val kotlinDevRepository = rootProject.findProperty("kotlin_dev_repository")
         if (kotlinDevRepository != null) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,8 @@ POM_DEVELOPER_EMAIL=software@drewhamilton.dev
 #endregion
 
 snapshot_dependencies_enabled=false
-kotlin_dev_version_enabled=false
+# Uncomment to enable dev versions of Kotlin dependencies:
+#kotlin_dev_repository=https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev
 
 # Workaround for https://github.com/Kotlin/dokka/issues/1405 on `./gradlew dokkaJavadoc`
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,8 @@ POM_DEVELOPER_NAME=Drew Hamilton
 POM_DEVELOPER_EMAIL=software@drewhamilton.dev
 #endregion
 
-snapshot_dependencies_enabled=false
+# Uncomment to enable snapshot dependencies:
+#snapshots_repository=https://oss.sonatype.org/content/repositories/snapshots
 # Uncomment to enable dev versions of Kotlin dependencies:
 #kotlin_dev_repository=https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev
 

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -31,9 +31,10 @@ allprojects {
         }
         mavenCentral()
 
-        if (rootProject.property("kotlin_dev_version_enabled") == "true") {
-            logger.lifecycle("Adding Kotlin dev repository for ${this@allprojects}")
-            maven { url = uri("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev") }
+        val kotlinDevRepository = rootProject.findProperty("kotlin_dev_repository")
+        if (kotlinDevRepository != null) {
+            logger.lifecycle("Adding <$kotlinDevRepository> repository for ${this@allprojects}")
+            maven { url = uri(kotlinDevRepository) }
         }
     }
 

--- a/sample/settings.gradle.kts
+++ b/sample/settings.gradle.kts
@@ -21,9 +21,10 @@ pluginManagement {
         mavenCentral()
         google()
 
-        if (extra["kotlin_dev_version_enabled"] == "true") {
-            logger.lifecycle("Adding Kotlin dev repository for plugins")
-            maven { url = uri("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev") }
+        if (extra.has("kotlin_dev_repository")) {
+            val kotlinDevRepository = extra["kotlin_dev_repository"]!!
+            logger.lifecycle("Adding <$kotlinDevRepository> repository for plugins")
+            maven { url = uri(kotlinDevRepository) }
         }
     }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,9 +18,10 @@ pluginManagement {
         // KSP:
         google()
 
-        if (extra["kotlin_dev_version_enabled"] == "true") {
-            logger.lifecycle("Adding Kotlin dev repository for plugins")
-            maven { url = uri("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev") }
+        if (extra.has("kotlin_dev_repository")) {
+            val kotlinDevRepository = extra["kotlin_dev_repository"]!!
+            logger.lifecycle("Adding <$kotlinDevRepository> repository for plugins")
+            maven { url = uri(kotlinDevRepository) }
         }
     }
 }


### PR DESCRIPTION
Their presence in Gradle code previously was causing Renovate to pull from the Kotlin dev repository even when it was disabled, e.g. in #264 and #268. I believe doing it this way will prevent Renovate from seeing the dev repository.