### PR TITLE
Support WASM

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import dev.drewhamilton.poko.build.setUpLocalSigning
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
+import org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -15,8 +16,13 @@ plugins {
 
 plugins.withType<NodeJsRootPlugin> {
     extensions.getByType<NodeJsRootExtension>().apply {
-        nodeVersion = "21.0.0"
+        nodeVersion = "22.0.0-v8-canary202312089dd1cd78d4"
+        nodeDownloadBaseUrl = "https://nodejs.org/download/v8-canary"
     }
+}
+
+tasks.withType<KotlinNpmInstallTask>().configureEach {
+    args.add("--ignore-engines")
 }
 
 allprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,9 @@ plugins {
 
 plugins.withType<NodeJsRootPlugin> {
     extensions.getByType<NodeJsRootExtension>().apply {
-        nodeVersion = "22.0.0-v8-canary202312089dd1cd78d4"
+        // WASM requires a canary Node.js version. This is the last v21 canary, and has both
+        // darwin-arm64 and darwin-x64 artifacts:
+        nodeVersion = "21.0.0-v8-canary20231024d0ddc81258"
         nodeDownloadBaseUrl = "https://nodejs.org/download/v8-canary"
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 
 plugins.withType<NodeJsRootPlugin> {
     extensions.getByType<NodeJsRootExtension>().apply {
-        nodeVersion = "20.0.0"
+        nodeVersion = "21.0.0"
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,7 @@
 import dev.drewhamilton.poko.build.setUpLocalSigning
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -9,6 +11,12 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.kotlinx.binaryCompatibilityValidator) apply false
     alias(libs.plugins.ksp) apply false
+}
+
+plugins.withType<NodeJsRootPlugin> {
+    extensions.getByType<NodeJsRootExtension>().apply {
+        nodeVersion = "20.0.0"
+    }
 }
 
 allprojects {

--- a/poko-annotations/build.gradle.kts
+++ b/poko-annotations/build.gradle.kts
@@ -27,6 +27,8 @@ kotlin {
   tvosX64()
   tvosSimulatorArm64()
 
+  wasm().nodejs()
+
   watchosArm32()
   watchosArm64()
   watchosDeviceArm64()

--- a/poko-annotations/build.gradle.kts
+++ b/poko-annotations/build.gradle.kts
@@ -27,7 +27,7 @@ kotlin {
   tvosX64()
   tvosSimulatorArm64()
 
-  wasm().nodejs()
+  wasmJs().nodejs()
 
   watchosArm32()
   watchosArm64()

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/equalsGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/equalsGeneration.kt
@@ -184,8 +184,8 @@ private fun IrBuilderWithScope.irArrayTypeCheckAndContentDeepEqualsBranch(
             condition = irIs(argument, type),
             thenPart = irCallContentDeepEquals(
                 classifier = classSymbol,
-                receiver = receiver,
-                argument = argument,
+                receiver = irImplicitCast(receiver, type),
+                argument = irImplicitCast(argument, type),
             ),
             elsePart = irFalse(),
         ),

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.ir.builders.irElseBranch
 import org.jetbrains.kotlin.ir.builders.irGet
 import org.jetbrains.kotlin.ir.builders.irGetField
 import org.jetbrains.kotlin.ir.builders.irIfNull
+import org.jetbrains.kotlin.ir.builders.irImplicitCast
 import org.jetbrains.kotlin.ir.builders.irInt
 import org.jetbrains.kotlin.ir.builders.irIs
 import org.jetbrains.kotlin.ir.builders.irReturn
@@ -232,7 +233,7 @@ private fun IrBlockBodyBuilder.irArrayTypeCheckAndContentDeepHashCodeBranch(
             callee = findArrayContentDeepHashCodeFunction(classSymbol),
             type = context.irBuiltIns.intType,
         ).apply {
-            extensionReceiver = value
+            extensionReceiver = irImplicitCast(value, type)
         }
     )
 }

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/toStringGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/toStringGeneration.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irConcat
 import org.jetbrains.kotlin.ir.builders.irElseBranch
 import org.jetbrains.kotlin.ir.builders.irGetField
+import org.jetbrains.kotlin.ir.builders.irImplicitCast
 import org.jetbrains.kotlin.ir.builders.irIs
 import org.jetbrains.kotlin.ir.builders.irReturn
 import org.jetbrains.kotlin.ir.builders.irString
@@ -175,7 +176,7 @@ private fun IrBlockBodyBuilder.irArrayTypeCheckAndContentDeepToStringBranch(
         condition = irIs(value, type),
         result = irCallToStringFunction(
             toStringFunctionSymbol = findContentDeepToStringFunctionSymbol(classSymbol),
-            value = value,
+            value = irImplicitCast(value, type),
         ),
     )
 }

--- a/poko-tests/build.gradle.kts
+++ b/poko-tests/build.gradle.kts
@@ -81,8 +81,8 @@ kotlin {
   tvosSimulatorArm64()
   tvosSimulatorArm64("tvosSimulatorArm64K2").applyK2()
 
-  wasm().nodejs()
-  wasm("wasmK2").applyK2().nodejs()
+  wasmJs().nodejs()
+  wasmJs("wasmJsK2").applyK2().nodejs()
 
   watchosArm32()
   watchosArm32("watchosArm32K2").applyK2()

--- a/poko-tests/build.gradle.kts
+++ b/poko-tests/build.gradle.kts
@@ -81,6 +81,9 @@ kotlin {
   tvosSimulatorArm64()
   tvosSimulatorArm64("tvosSimulatorArm64K2").applyK2()
 
+  wasm().nodejs()
+  wasm("wasmK2").applyK2().nodejs()
+
   watchosArm32()
   watchosArm32("watchosArm32K2").applyK2()
   watchosArm64()


### PR DESCRIPTION
Closes #235.

Adds the `wasmJs` target to the `:poko-annotations` and `:poko-tests` projects.

Adds explicit `irImplicitCast` calls after `irIs` checks to avoid compile errors: the WASM target doesn't generate these automatically like other targets do. I posted a public Slack message about it [here](https://kotlinlang.slack.com/archives/C7L3JB43G/p1702592212316199).

The WASM target currently requires a canary Node.js version. I'm unclear on the implications of shipping with this, will follow up in this PR's comments.