### PR TITLE
Move publishing configuration mostly into the build support plugin

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,12 +1,12 @@
 # Releasing
 
  1. Make sure you're on the latest commit on the main branch.
- 2. Change `pokoVersion` in `build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildPlugin.kt` to a non-SNAPSHOT version.
+ 2. Change `PUBLISH_VERSION` in gradle.properties to a non-SNAPSHOT version.
  3. Update README.md for the impending release.
  4. Update CHANGELOG.md for the impending release.
  5. Commit (don't push) the changes with message "Release x.y.z", where x.y.z is the new version.
  6. Tag the commit `x.y.z`, where x.y.z is the new version.
- 7. Change `pokoVersion` in `build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildPlugin.kt` to the next SNAPSHOT version.
+ 7. Change `PUBLISH_VERSION` in gradle.properties to the next SNAPSHOT version.
  8. Commit the snapshot change.
  9. Push the tag and 2 commits to origin/main.
 10. Wait for the "Release" Action to complete.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,12 +1,12 @@
 # Releasing
 
  1. Make sure you're on the latest commit on the main branch.
- 2. Change `VERSION_NAME` in gradle.properties to a non-SNAPSHOT version.
+ 2. Change `pokoVersion` in `build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildPlugin.kt` to a non-SNAPSHOT version.
  3. Update README.md for the impending release.
  4. Update CHANGELOG.md for the impending release.
  5. Commit (don't push) the changes with message "Release x.y.z", where x.y.z is the new version.
  6. Tag the commit `x.y.z`, where x.y.z is the new version.
- 7. Change `VERSION_NAME` in gradle.properties to the next SNAPSHOT version.
+ 7. Change `pokoVersion` in `build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildPlugin.kt` to the next SNAPSHOT version.
  8. Commit the snapshot change.
  9. Push the tag and 2 commits to origin/main.
 10. Wait for the "Release" Action to complete.

--- a/artifact-info-template/ArtifactInfo.kt
+++ b/artifact-info-template/ArtifactInfo.kt
@@ -6,7 +6,6 @@ internal object ArtifactInfo {
 
     const val ANNOTATIONS_ARTIFACT = "$annotationsArtifact"
     const val COMPILER_PLUGIN_ARTIFACT = "$compilerPluginArtifact"
-    const val GRADLE_PLUGIN_ARTIFACT = "$gradlePluginArtifact"
 
     const val DEFAULT_POKO_ENABLED = true
     const val DEFAULT_POKO_ANNOTATION = "dev/drewhamilton/poko/Poko"

--- a/build-support/build.gradle.kts
+++ b/build-support/build.gradle.kts
@@ -9,6 +9,8 @@ repositories {
 
 dependencies {
     implementation(libs.kotlin.gradleApi)
+    implementation(libs.plugin.mavenPublish)
+    implementation(libs.plugin.dokka)
 }
 
 gradlePlugin {

--- a/build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildExtension.kt
+++ b/build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildExtension.kt
@@ -1,6 +1,6 @@
 package dev.drewhamilton.poko.build
 
 interface PokoBuildExtension {
-    fun publishing()
+    fun publishing(pomDescription: String)
     fun generateArtifactInfo(basePackage: String)
 }

--- a/build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildExtension.kt
+++ b/build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildExtension.kt
@@ -1,6 +1,6 @@
 package dev.drewhamilton.poko.build
 
 interface PokoBuildExtension {
-    fun publishing(pomDescription: String)
+    fun publishing(pomName: String)
     fun generateArtifactInfo(basePackage: String)
 }

--- a/build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildPlugin.kt
+++ b/build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildPlugin.kt
@@ -1,6 +1,7 @@
 package dev.drewhamilton.poko.build
 
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import com.vanniktech.maven.publish.SonatypeHost
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -48,7 +49,38 @@ class PokoBuildPlugin : Plugin<Project> {
 
                 pom {
                     name.set(pomName)
+
+                    description.set("A Kotlin compiler plugin for generating equals, hashCode, and toString for plain old Kotlin objects.")
+                    url.set("https://github.com/drewhamilton/Poko")
+
+                    licenses {
+                        license {
+                            name.set("The Apache Software License, Version 2.0")
+                            url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                            distribution.set("repo")
+                        }
+                    }
+
+                    scm {
+                        url.set("https://github.com/drewhamilton/Poko/tree/main")
+                        connection.set("scm:git:github.com/drewhamilton/Poko.git")
+                        developerConnection.set("scm:git:ssh://github.com/drewhamilton/Poko.git")
+                    }
+
+                    developers {
+                        developer {
+                            id.set("drewhamilton")
+                            name.set("Drew Hamilton")
+                            email.set("software@drewhamilton.dev")
+                        }
+                    }
                 }
+
+                signAllPublications()
+                publishToMavenCentral(
+                    host = SonatypeHost.DEFAULT,
+                    automaticRelease = true,
+                )
             }
 
             project.pluginManager.apply("org.jetbrains.dokka")

--- a/build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildPlugin.kt
+++ b/build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildPlugin.kt
@@ -38,7 +38,7 @@ class PokoBuildPlugin : Plugin<Project> {
     private class PokoBuildExtensionImpl(
         private val project: Project,
     ) : PokoBuildExtension {
-        override fun publishing(pomDescription: String) {
+        override fun publishing(pomName: String) {
             project.pluginManager.apply("com.vanniktech.maven.publish")
 
             val mavenPublishing = project.extensions.getByName("mavenPublishing") as MavenPublishBaseExtension
@@ -47,7 +47,7 @@ class PokoBuildPlugin : Plugin<Project> {
                 coordinates(project.pokoGroupId, project.name, project.pokoVersion)
 
                 pom {
-                    description.set(pomDescription)
+                    name.set(pomName)
                 }
             }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,8 +6,6 @@ import org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    alias(libs.plugins.dokka) apply false
-    alias(libs.plugins.mavenPublish) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.kotlinx.binaryCompatibilityValidator) apply false
@@ -28,8 +26,6 @@ tasks.withType<KotlinNpmInstallTask>().configureEach {
 }
 
 allprojects {
-    group = rootProject.property("GROUP")!!
-    version = rootProject.property("VERSION_NAME")!!
     setUpLocalSigning()
 
     repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,5 @@
 kotlin.code.style=official
 
-GROUP=dev.drewhamilton.poko
-VERSION_NAME=0.16.0-SNAPSHOT
-
 #region More publish info
 RELEASE_SIGNING_ENABLED=true
 SONATYPE_HOST=DEFAULT

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,27 +3,6 @@ kotlin.code.style=official
 PUBLISH_GROUP=dev.drewhamilton.poko
 PUBLISH_VERSION=0.16.0-SNAPSHOT
 
-#region More publish info
-RELEASE_SIGNING_ENABLED=true
-SONATYPE_HOST=DEFAULT
-SONATYPE_AUTOMATIC_RELEASE=true
-
-POM_DESCRIPTION=A Kotlin compiler plugin for generating equals, hashCode, and toString for plain old Kotlin objects.
-POM_URL=https://github.com/drewhamilton/Poko
-
-POM_LICENSE_NAME=The Apache Software License, Version 2.0
-POM_LICENSE_URL=https://www.apache.org/licenses/LICENSE-2.0.txt
-POM_LICENSE_DIST=repo
-
-POM_SCM_URL=https://github.com/drewhamilton/Poko/tree/main
-POM_SCM_CONNECTION=scm:git:github.com/drewhamilton/Poko.git
-POM_SCM_DEV_CONNECTION=scm:git:ssh://github.com/drewhamilton/Poko.git
-
-POM_DEVELOPER_ID=drewhamilton
-POM_DEVELOPER_NAME=Drew Hamilton
-POM_DEVELOPER_EMAIL=software@drewhamilton.dev
-#endregion
-
 # Uncomment to enable snapshot dependencies:
 #snapshots_repository=https://oss.sonatype.org/content/repositories/snapshots
 # Uncomment to enable dev versions of Kotlin dependencies:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,8 @@
 kotlin.code.style=official
 
+PUBLISH_GROUP=dev.drewhamilton.poko
+PUBLISH_VERSION=0.16.0-SNAPSHOT
+
 #region More publish info
 RELEASE_SIGNING_ENABLED=true
 SONATYPE_HOST=DEFAULT

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,13 +31,14 @@ assertk = "com.willowtreeapps.assertk:assertk:0.28.0"
 asm-util = "org.ow2.asm:asm-util:9.6"
 testParameterInjector = "com.google.testparameterinjector:test-parameter-injector:1.14"
 
+plugin-mavenPublish = "com.vanniktech:gradle-maven-publish-plugin:0.25.3"
+plugin-dokka = "org.jetbrains.dokka:dokka-gradle-plugin:1.9.10"
+
 [plugins]
 
 android-library = { id = "com.android.library", version = "8.2.0" }
-dokka = { id = "org.jetbrains.dokka", version = "1.9.10" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinx-binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.13.2" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.25.3" }

--- a/poko-annotations/build.gradle.kts
+++ b/poko-annotations/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 pokoBuild {
-  publishing()
+  publishing("Poko Annotations")
 }
 
 kotlin {

--- a/poko-annotations/gradle.properties
+++ b/poko-annotations/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=poko-annotations
-POM_NAME=Poko Annotations

--- a/poko-compiler-plugin/build.gradle.kts
+++ b/poko-compiler-plugin/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 pokoBuild {
-    publishing()
+    publishing("Poko Compiler Plugin")
     generateArtifactInfo("dev.drewhamilton.poko")
 }
 

--- a/poko-compiler-plugin/gradle.properties
+++ b/poko-compiler-plugin/gradle.properties
@@ -1,5 +1,2 @@
-POM_ARTIFACT_ID=poko-compiler-plugin
-POM_NAME=Poko Compiler Plugin
-
 # We want the stdlib as a compileOnly dependency.
 kotlin.stdlib.default.dependency=false

--- a/poko-gradle-plugin/build.gradle.kts
+++ b/poko-gradle-plugin/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 pokoBuild {
-    publishing()
+    publishing("Poko Gradle Plugin")
     generateArtifactInfo("dev.drewhamilton.poko.gradle")
 }
 

--- a/poko-gradle-plugin/gradle.properties
+++ b/poko-gradle-plugin/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=poko-gradle-plugin
-POM_NAME=Poko Gradle Plugin

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -25,7 +25,7 @@ allprojects {
             exclusiveContent {
                 forRepository { mavenLocal() }
                 filter {
-                    includeGroup(property("GROUP") as String)
+                    includeGroup(property("PUBLISH_GROUP") as String)
                 }
             }
         }

--- a/sample/properties.gradle
+++ b/sample/properties.gradle
@@ -4,9 +4,6 @@
 List<String> propertiesFiles = [
     "../gradle.properties",
     "../local.properties",
-    "../poko-annotations/gradle.properties",
-    "../poko-compiler-plugin/gradle.properties",
-    "../poko-gradle-plugin/gradle.properties",
 ]
 
 propertiesFiles.each { fileName ->

--- a/sample/settings.gradle.kts
+++ b/sample/settings.gradle.kts
@@ -13,7 +13,7 @@ pluginManagement {
             exclusiveContent {
                 forRepository { mavenLocal() }
                 filter {
-                    val publishGroup = extra["GROUP"] as String
+                    val publishGroup = extra["PUBLISH_GROUP"] as String
                     includeGroup(publishGroup)
                 }
             }
@@ -29,7 +29,7 @@ pluginManagement {
     }
 
     resolutionStrategy {
-        val publishVersion = extra["VERSION_NAME"] as String
+        val publishVersion = extra["PUBLISH_VERSION"] as String
         eachPlugin {
             if (requested.id.id == "dev.drewhamilton.poko") {
                 useVersion(publishVersion)
@@ -56,7 +56,7 @@ if (!isCi) {
     // Use local Poko modules for non-CI builds:
     includeBuild("../.") {
         logger.lifecycle("Replacing Poko module dependencies with local projects")
-        val publishGroup: String = extra["GROUP"] as String
+        val publishGroup: String = extra["PUBLISH_GROUP"] as String
         dependencySubstitution {
             substitute(module("$publishGroup:${extra["poko-annotations.POM_ARTIFACT_ID"]}"))
                 .using(project(":poko-annotations"))


### PR DESCRIPTION
Revives and finishes #188. Moves all publication settings into the build support plugin except for the group and version. These are currently both needed in `gradle.properties` so they can be read by both the main project and the sample. The build support plugin now manually reads these from `gradle.properties` and passes them to the publish plugin.