### PR TITLE
Apply Foojay Toolchains Plugin

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,6 +31,7 @@ pluginManagement {
 
 plugins {
     id("dev.drewhamilton.poko.settings")
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
 }
 
 rootProject.name = "Poko"


### PR DESCRIPTION
Sets up toolchain download repositories when a JDK needs to be downloaded by the build