### PR TITLE
Use `entries` property on enums

### DIFF
--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/equalsGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/equalsGeneration.kt
@@ -151,7 +151,7 @@ private fun IrBuilderWithScope.irRuntimeArrayContentDeepEquals(
 
             // Map each primitive type to a `when` branch covering its respective primitive array
             // type:
-            *PrimitiveType.values().map { primitiveType ->
+            *PrimitiveType.entries.map { primitiveType ->
                 irArrayTypeCheckAndContentDeepEqualsBranch(
                     receiver = receiver,
                     argument = argument,

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
@@ -193,7 +193,7 @@ private fun IrBlockBodyBuilder.irRuntimeArrayContentDeepHashCode(
 
             // Map each primitive type to a `when` branch covering its respective primitive array
             // type:
-            *PrimitiveType.values().map { primitiveType ->
+            *PrimitiveType.entries.map { primitiveType ->
                 irArrayTypeCheckAndContentDeepHashCodeBranch(
                     value = value,
                     classSymbol = with(context) { primitiveType.toPrimitiveArrayClassSymbol() },

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/toStringGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/toStringGeneration.kt
@@ -145,7 +145,7 @@ private fun IrBlockBodyBuilder.irRuntimeArrayContentDeepToString(
 
             // Map each primitive type to a `when` branch covering its respective primitive array
             // type:
-            *PrimitiveType.values().map { primitiveType ->
+            *PrimitiveType.entries.map { primitiveType ->
                 irArrayTypeCheckAndContentDeepToStringBranch(
                     value = value,
                     classSymbol = with(context) { primitiveType.toPrimitiveArrayClassSymbol() },


### PR DESCRIPTION
Revives #205. The class generated by them is now filtered out of the binary compatibility validator's output.

> $EntriesMappings classes backing Kotlin's 1.9 Enum.entries are now filtered out (Kotlin/binary-compatibility-validator#144)