### PR TITLE
Set `:poko-tests` JVM toolchain version via CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
 
       - name: Test
         run: ./gradlew :poko-tests:jvmTest :poko-tests:jvmK2Test --stacktrace
+        env:
+          poko_tests_jvm_toolchain_version: ${{ matrix.poko_tests_jvm_toolchain_version }}
 
   build-sample:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,17 +58,14 @@ jobs:
   build-sample:
     runs-on: ubuntu-latest
     needs: build
-    strategy:
-      matrix:
-        ci_java_version: [ 8, 11, 17, 21 ]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-      - name: Install JDK ${{ matrix.ci_java_version }}
+      - name: Install JDK
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: ${{ matrix.ci_java_version }}
+          java-version: 21
       - name: Download MavenLocal
         uses: actions/download-artifact@v4
         with:
@@ -80,8 +77,6 @@ jobs:
 
       - name: Build sample
         run: cd sample && ./gradlew build --stacktrace
-        env:
-          ci_java_version: ${{ matrix.ci_java_version }}
 
 env:
   GRADLE_OPTS: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: |
-            8
-            11
-            17
-            21
+          java-version: 21
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3
@@ -35,6 +31,29 @@ jobs:
           name: MavenLocal
           path: ~/.m2/repository/dev/drewhamilton/poko/
           if-no-files-found: error
+
+  test-with-jdk:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        poko_tests_jvm_toolchain_version: [ 8, 11, 17 ]
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Install JDK ${{ matrix.poko_tests_jvm_toolchain_version }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: |
+            ${{ matrix.poko_tests_jvm_toolchain_version }}
+            21
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Test
+        run: ./gradlew :poko-tests:jvmTest :poko-tests:jvmK2Test --stacktrace
 
   build-sample:
     runs-on: ubuntu-latest

--- a/poko-tests/build.gradle.kts
+++ b/poko-tests/build.gradle.kts
@@ -1,28 +1,13 @@
-import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 import org.jetbrains.kotlin.gradle.plugin.NATIVE_COMPILER_PLUGIN_CLASSPATH_CONFIGURATION_NAME
 import org.jetbrains.kotlin.gradle.plugin.PLUGIN_CLASSPATH_CONFIGURATION_NAME
-import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
 
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
 }
 
-fun KotlinMultiplatformExtension.jvm(
-  version: Int,
-  baseName: String = "jvm",
-): KotlinJvmTarget {
-  return jvm(baseName.replace("jvm", "jvm$version")) {
-    compilations.configureEach {
-      jvmToolchain(version)
-    }
-
-    // Dummy value required to disambiguate these targets' configurations.
-    // See https://kotlinlang.org/docs/multiplatform-set-up-targets.html#distinguish-several-targets-for-one-platform
-    attributes.attribute(Attribute.of("com.example.JvmTarget", Int::class.javaObjectType), version)
-  }
-}
+val jvmToolchainVersion: Int? = System.getenv()["poko_tests_jvm_toolchain_version"]?.toInt()
 
 fun <T : KotlinTarget> T.applyK2(): T {
   compilations.configureEach {
@@ -35,8 +20,6 @@ fun <T : KotlinTarget> T.applyK2(): T {
 
   return this
 }
-
-val jvmToolchainVersion: Int? = System.getenv()["poko_tests_jvm_toolchain_version"]?.toInt()
 
 kotlin {
   jvmToolchainVersion?.let { jvmToolchain(it) }

--- a/poko-tests/build.gradle.kts
+++ b/poko-tests/build.gradle.kts
@@ -36,14 +36,11 @@ fun <T : KotlinTarget> T.applyK2(): T {
   return this
 }
 
+val jvmToolchainVersion: Int? = System.getenv()["poko_tests_jvm_toolchain_version"]?.toInt()
+
 kotlin {
-  jvm(8)
-  jvm(8, "jvmK2").applyK2()
-  jvm(11)
-  jvm(11, "jvmK2").applyK2()
-  jvm(17)
-  jvm(17, "jvmK2").applyK2()
-  // Build JDK which should be latest:
+  jvmToolchainVersion?.let { jvmToolchain(it) }
+
   jvm()
   jvm("jvmK2").applyK2()
 

--- a/poko-tests/performance/build.gradle.kts
+++ b/poko-tests/performance/build.gradle.kts
@@ -11,5 +11,4 @@ dependencies {
 tasks.named("test") {
     dependsOn(":poko-tests:compileProductionExecutableKotlinJs")
     dependsOn(":poko-tests:compileKotlinJvm")
-    dependsOn(":poko-tests:compileKotlinJvm11")
 }

--- a/poko-tests/performance/src/test/kotlin/JvmPerformanceTest.kt
+++ b/poko-tests/performance/src/test/kotlin/JvmPerformanceTest.kt
@@ -27,8 +27,8 @@ class JvmPerformanceTest {
     @Test fun `toString uses invokedynamic on modern JDKs`() {
         val classfile = jvmOutput("performance/IntAndLong.class")
         val bytecode = bytecodeToText(classfile.readBytes()).also {
-            // Class version 55 == Java 11
-            it.assumeMinimumClassVersion(55)
+            // Java 9
+            it.assumeMinimumClassVersion(53)
         }
 
         assertThat(bytecode).all {

--- a/poko-tests/performance/src/test/kotlin/JvmPerformanceTest.kt
+++ b/poko-tests/performance/src/test/kotlin/JvmPerformanceTest.kt
@@ -4,6 +4,7 @@ import assertk.assertions.contains
 import assertk.assertions.doesNotContain
 import org.junit.AssumptionViolatedException
 import org.junit.Test
+import org.objectweb.asm.ClassReader
 
 class JvmPerformanceTest {
     @Test fun `int property does not emit hashCode method invocation`() {
@@ -26,20 +27,19 @@ class JvmPerformanceTest {
 
     @Test fun `toString uses invokedynamic on modern JDKs`() {
         val classfile = jvmOutput("performance/IntAndLong.class")
-        val bytecode = bytecodeToText(classfile.readBytes()).also {
-            // Java 9
-            it.assumeMinimumClassVersion(53)
-        }
-
+        val classReader = ClassReader(classfile.readBytes())
+        // Java 9 == class file major version 53:
+        classReader.assumeMinimumClassVersion(53)
+        val bytecode = classReader.toText()
         assertThat(bytecode).all {
             contains("INVOKEDYNAMIC makeConcatWithConstants")
             doesNotContain("StringBuilder")
         }
     }
 
-    private fun String.assumeMinimumClassVersion(version: Int) {
-        val classVersionRegex = Regex("class version [\\d.]* \\((\\d*)\\)")
-        val actualClassVersion = classVersionRegex.find(this)!!.groups.last()!!.value.toInt()
+    private fun ClassReader.assumeMinimumClassVersion(version: Int) {
+        // Class file major version is a two-byte integer at offset 6:
+        val actualClassVersion = readShort(6)
         if (actualClassVersion < version) {
             throw AssumptionViolatedException("This test only works class version $version+")
         }

--- a/poko-tests/performance/src/test/kotlin/JvmPerformanceTest.kt
+++ b/poko-tests/performance/src/test/kotlin/JvmPerformanceTest.kt
@@ -27,6 +27,7 @@ class JvmPerformanceTest {
     @Test fun `toString uses invokedynamic on modern JDKs`() {
         val classfile = jvmOutput("performance/IntAndLong.class")
         val bytecode = bytecodeToText(classfile.readBytes()).also {
+            // Class version 55 == Java 11
             it.assumeMinimumClassVersion(55)
         }
 

--- a/poko-tests/performance/src/test/kotlin/asm.kt
+++ b/poko-tests/performance/src/test/kotlin/asm.kt
@@ -5,8 +5,12 @@ import org.objectweb.asm.util.Textifier
 import org.objectweb.asm.util.TraceClassVisitor
 
 fun bytecodeToText(bytecode: ByteArray): String {
+    return ClassReader(bytecode).toText()
+}
+
+fun ClassReader.toText(): String {
     val textifier = Textifier()
-    ClassReader(bytecode).accept(TraceClassVisitor(null, textifier, null), 0)
+    accept(TraceClassVisitor(null, textifier, null), 0)
 
     val writer = StringWriter()
     textifier.print(PrintWriter(writer))

--- a/poko-tests/performance/src/test/kotlin/sources.kt
+++ b/poko-tests/performance/src/test/kotlin/sources.kt
@@ -1,7 +1,4 @@
 import java.io.File
 
-fun jvmOutput(relativePath: String, version: Int = -1): File {
-    val number = if (version == -1) "" else "$version"
-    return File("../build/classes/kotlin/jvm$number/main", relativePath)
-}
+fun jvmOutput(relativePath: String) = File("../build/classes/kotlin/jvm/main", relativePath)
 fun jsOutput() = File("../build/compileSync/js/main/productionExecutable/kotlin/Poko-poko-tests.js")


### PR DESCRIPTION
From my understanding of the errors on #258, calling `jvmToolchain` per-compilation in Kotlin Multiplatform is [disallowed in Kotlin 2](https://youtrack.jetbrains.com/issue/KT-64629/Gradle-configuration-fails-fun-jvmToolchainjdkVersion-Int-Unit-cant-be-called-in-this-context-by-implicit-receiver). This alternative makes the CI less efficient by needing to spin up more machines, but hopefully doesn't make it slower since the new machines are Ubuntu and will run in parallel to the main build. Happy to change the approach if there's a better way.