### PR TITLE
Add `-Xjdk-release` flag to released modules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,6 +57,7 @@ allprojects {
             project.tasks.withType<KotlinCompile>().configureEach {
                 compilerOptions {
                     jvmTarget.set(JvmTarget.fromTarget(javaVersion.toString()))
+                    freeCompilerArgs.add("-Xjdk-release=$javaVersion")
                 }
             }
         }


### PR DESCRIPTION
Per [Jake's blog post](https://jakewharton.com/kotlins-jdk-release-compatibility-flag/).