### PR TITLE
Compile with JDK 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,8 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 22
+          # TODO: Bump to 22 when Gradle supports Kotlin 2.0 in buildSrc
+          java-version: 21
       - name: Download MavenLocal
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 21
+          java-version: 22
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        poko_tests_jvm_toolchain_version: [ 8, 11, 17 ]
+        poko_tests_jvm_toolchain_version: [ 8, 11, 17, 21 ]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -67,7 +67,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 21
+          java-version: 22
       - name: Download MavenLocal
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 21
+          java-version: 22
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3


### PR DESCRIPTION
Gradle 8.7 doesn't technically support being run with Java 22, but maybe it'll work anyway. Otherwise this can wait for the next Gradle release.