### PR TITLE
Use Kotlin's default Node version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,15 +12,6 @@ plugins {
     alias(libs.plugins.ksp) apply false
 }
 
-plugins.withType<NodeJsRootPlugin> {
-    extensions.getByType<NodeJsRootExtension>().apply {
-        // WASM requires a canary Node.js version. This is the last v22 nightly that supports
-        // darwin-arm64, darwin-x64 and win-x64 artifacts:
-        nodeVersion = "22.0.0-nightly20240410c82f3c9e80"
-        nodeDownloadBaseUrl = "https://nodejs.org/download/nightly"
-    }
-}
-
 tasks.withType<KotlinNpmInstallTask>().configureEach {
     args.add("--ignore-engines")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,10 +12,6 @@ plugins {
     alias(libs.plugins.ksp) apply false
 }
 
-tasks.withType<KotlinNpmInstallTask>().configureEach {
-    args.add("--ignore-engines")
-}
-
 allprojects {
     setUpLocalSigning()
 


### PR DESCRIPTION
v22 as of Kotlin 1.9.24