### PR TITLE
Deprecate `@ArrayContentSupport` annotation

### DIFF
--- a/poko-annotations/src/commonMain/kotlin/dev/drewhamilton/poko/ArrayContentBased.kt
+++ b/poko-annotations/src/commonMain/kotlin/dev/drewhamilton/poko/ArrayContentBased.kt
@@ -23,7 +23,6 @@ package dev.drewhamilton.poko
  * different `equals` and `hashCode` results at different times. This annotation should only be used
  * by consumers for whom performant code is more important than safe code.
  */
-@ArrayContentSupport
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.PROPERTY)
 public annotation class ArrayContentBased

--- a/poko-annotations/src/commonMain/kotlin/dev/drewhamilton/poko/ArrayContentSupport.kt
+++ b/poko-annotations/src/commonMain/kotlin/dev/drewhamilton/poko/ArrayContentSupport.kt
@@ -4,5 +4,6 @@ package dev.drewhamilton.poko
  * Denotes an API that enables support for array content reading, which is experimental and may
  * change or break.
  */
+@Deprecated("Array content support no longer requires opt-in")
 @RequiresOptIn
 public annotation class ArrayContentSupport

--- a/poko-compiler-plugin/src/test/resources/illegal/GenericArrayHolder.kt
+++ b/poko-compiler-plugin/src/test/resources/illegal/GenericArrayHolder.kt
@@ -1,11 +1,9 @@
 package illegal
 
 import dev.drewhamilton.poko.ArrayContentBased
-import dev.drewhamilton.poko.ArrayContentSupport
 import dev.drewhamilton.poko.Poko
 
 @Suppress("Unused")
-@OptIn(ArrayContentSupport::class)
 @Poko class GenericArrayHolder<G : Collection<*>>(
     @ArrayContentBased val generic: G,
 )

--- a/poko-compiler-plugin/src/test/resources/illegal/NotArrayHolder.kt
+++ b/poko-compiler-plugin/src/test/resources/illegal/NotArrayHolder.kt
@@ -1,11 +1,9 @@
 package illegal
 
-import dev.drewhamilton.poko.ArrayContentSupport
-import dev.drewhamilton.poko.Poko
 import dev.drewhamilton.poko.ArrayContentBased
+import dev.drewhamilton.poko.Poko
 
 @Suppress("Unused")
-@OptIn(ArrayContentSupport::class)
 @Poko class NotArrayHolder(
     @ArrayContentBased val string: String,
     @ArrayContentBased val int: Int,

--- a/poko-tests-without-k2/src/commonMain/kotlin/poko/AnyArrayHolder.kt
+++ b/poko-tests-without-k2/src/commonMain/kotlin/poko/AnyArrayHolder.kt
@@ -1,11 +1,9 @@
 package poko
 
 import dev.drewhamilton.poko.ArrayContentBased
-import dev.drewhamilton.poko.ArrayContentSupport
 import dev.drewhamilton.poko.Poko
 
 @Suppress("Unused")
-@OptIn(ArrayContentSupport::class)
 @Poko class AnyArrayHolder(
     @ArrayContentBased val any: Any,
     @ArrayContentBased val nullableAny: Any?,

--- a/poko-tests-without-k2/src/commonMain/kotlin/poko/ArrayHolder.kt
+++ b/poko-tests-without-k2/src/commonMain/kotlin/poko/ArrayHolder.kt
@@ -1,11 +1,9 @@
 package poko
 
 import dev.drewhamilton.poko.ArrayContentBased
-import dev.drewhamilton.poko.ArrayContentSupport
 import dev.drewhamilton.poko.Poko
 
 @Suppress("Unused")
-@OptIn(ArrayContentSupport::class)
 @Poko class ArrayHolder(
     @ArrayContentBased val stringArray: Array<String>,
     @ArrayContentBased val nullableStringArray: Array<String>?,

--- a/poko-tests-without-k2/src/commonMain/kotlin/poko/ComplexGenericArrayHolder.kt
+++ b/poko-tests-without-k2/src/commonMain/kotlin/poko/ComplexGenericArrayHolder.kt
@@ -1,11 +1,9 @@
 package poko
 
 import dev.drewhamilton.poko.ArrayContentBased
-import dev.drewhamilton.poko.ArrayContentSupport
 import dev.drewhamilton.poko.Poko
 
 @Suppress("Unused")
-@OptIn(ArrayContentSupport::class)
 @Poko class ComplexGenericArrayHolder<A : Any, G : A>(
     @ArrayContentBased val generic: G,
 )

--- a/poko-tests-without-k2/src/commonMain/kotlin/poko/GenericArrayHolder.kt
+++ b/poko-tests-without-k2/src/commonMain/kotlin/poko/GenericArrayHolder.kt
@@ -1,11 +1,9 @@
 package poko
 
 import dev.drewhamilton.poko.ArrayContentBased
-import dev.drewhamilton.poko.ArrayContentSupport
 import dev.drewhamilton.poko.Poko
 
 @Suppress("Unused")
-@OptIn(ArrayContentSupport::class)
 @Poko class GenericArrayHolder<G>(
     @ArrayContentBased val generic: G,
 )

--- a/poko-tests/src/commonMain/kotlin/poko/AnyArrayHolder.kt
+++ b/poko-tests/src/commonMain/kotlin/poko/AnyArrayHolder.kt
@@ -1,11 +1,9 @@
 package poko
 
 import dev.drewhamilton.poko.ArrayContentBased
-import dev.drewhamilton.poko.ArrayContentSupport
 import dev.drewhamilton.poko.Poko
 
 @Suppress("Unused")
-@OptIn(ArrayContentSupport::class)
 @Poko class AnyArrayHolder(
     @ArrayContentBased val any: Any,
     @ArrayContentBased val nullableAny: Any?,

--- a/poko-tests/src/commonMain/kotlin/poko/ArrayHolder.kt
+++ b/poko-tests/src/commonMain/kotlin/poko/ArrayHolder.kt
@@ -1,11 +1,9 @@
 package poko
 
 import dev.drewhamilton.poko.ArrayContentBased
-import dev.drewhamilton.poko.ArrayContentSupport
 import dev.drewhamilton.poko.Poko
 
 @Suppress("Unused")
-@OptIn(ArrayContentSupport::class)
 @Poko class ArrayHolder(
     @ArrayContentBased val stringArray: Array<String>,
     @ArrayContentBased val nullableStringArray: Array<String>?,

--- a/poko-tests/src/commonMain/kotlin/poko/ComplexGenericArrayHolder.kt
+++ b/poko-tests/src/commonMain/kotlin/poko/ComplexGenericArrayHolder.kt
@@ -1,11 +1,9 @@
 package poko
 
 import dev.drewhamilton.poko.ArrayContentBased
-import dev.drewhamilton.poko.ArrayContentSupport
 import dev.drewhamilton.poko.Poko
 
 @Suppress("Unused")
-@OptIn(ArrayContentSupport::class)
 @Poko class ComplexGenericArrayHolder<A : Any, G : A>(
     @ArrayContentBased val generic: G,
 )

--- a/poko-tests/src/commonMain/kotlin/poko/GenericArrayHolder.kt
+++ b/poko-tests/src/commonMain/kotlin/poko/GenericArrayHolder.kt
@@ -1,11 +1,9 @@
 package poko
 
 import dev.drewhamilton.poko.ArrayContentBased
-import dev.drewhamilton.poko.ArrayContentSupport
 import dev.drewhamilton.poko.Poko
 
 @Suppress("Unused")
-@OptIn(ArrayContentSupport::class)
 @Poko class GenericArrayHolder<G>(
     @ArrayContentBased val generic: G,
 )


### PR DESCRIPTION
This has been in used for awhile and doesn't seem to need changes.