### PR TITLE
Revert to building with JDK 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 22
+          ## TODO: Bump to 22 when Gradle supports it
+          java-version: 21
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,8 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 22
+          ## TODO: Bump to 22 when Gradle supports it
+          java-version: 21
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3


### PR DESCRIPTION
Apparently #325 was premature, as Gradle does [not yet support Java 22](https://docs.gradle.org/current/userguide/compatibility.html) as of Gradle 8.7. I'm not sure why it worked for a few days, including for the 0.16.0-beta01 release, but it's not critical so I'll just get the 0.16.0 release out the door with JDK 21.