### PR TITLE
Do not include DOM compat library for JS targets

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,9 @@
 kotlin.code.style=official
 
+# Do not include DOM compatibility dependency for JS targets.
+# See https://youtrack.jetbrains.com/issue/KT-35973 for more info.
+kotlin.js.stdlib.dom.api.included=false
+
 PUBLISH_GROUP=dev.drewhamilton.poko
 PUBLISH_VERSION=0.17.0-SNAPSHOT
 


### PR DESCRIPTION
Today:
```
|    \--- dev.drewhamilton.poko:poko-annotations:0.16.0
|         \--- dev.drewhamilton.poko:poko-annotations-js:0.16.0
|              +--- org.jetbrains.kotlin:kotlin-dom-api-compat:2.0.0 (*)
|              \--- org.jetbrains.kotlin:kotlin-stdlib:2.0.0 (*)
```

After this change:
```
|    \--- dev.drewhamilton.poko:poko-annotations:0.16.0
|         \--- dev.drewhamilton.poko:poko-annotations-js:0.16.0
|              \--- org.jetbrains.kotlin:kotlin-stdlib:2.0.0 (*)
```