### PR TITLE
Remove isArrayOrPrimitiveArray() function

### DIFF
--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/equalsGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/equalsGeneration.kt
@@ -37,6 +37,7 @@ import org.jetbrains.kotlin.ir.types.classifierOrFail
 import org.jetbrains.kotlin.ir.types.classifierOrNull
 import org.jetbrains.kotlin.ir.types.isNullable
 import org.jetbrains.kotlin.ir.util.defaultType
+import org.jetbrains.kotlin.ir.util.isArrayOrPrimitiveArray
 import org.jetbrains.kotlin.ir.util.render
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.FqName
@@ -110,7 +111,7 @@ private fun IrBuilderWithScope.irArrayContentDeepEquals(
     val propertyType = property.type
     val propertyClassifier = propertyType.classifierOrFail
 
-    val isArray = with(context) { propertyClassifier.isArrayOrPrimitiveArray() }
+    val isArray = propertyClassifier.isArrayOrPrimitiveArray(context.irBuiltIns)
     if (!isArray) {
         val mayBeRuntimeArray = with(context) { propertyClassifier.mayBeRuntimeArray() }
         return if (mayBeRuntimeArray) {

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/functionGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/functionGeneration.kt
@@ -97,15 +97,6 @@ private val arrayContentBasedAnnotationFqName = ClassId(
 ).asSingleFqName()
 
 /**
- * Returns true if the classifier represents a typed or primitive array.
- */
-context(IrGeneratorContextInterface)
-internal fun IrClassifierSymbol?.isArrayOrPrimitiveArray(): Boolean {
-    return this == irBuiltIns.arrayClass ||
-        this in irBuiltIns.primitiveArraysToPrimitiveTypes
-}
-
-/**
  * Returns true if the classifier represents a type that may be an array at runtime (e.g. [Any] or
  * a generic type).
  */

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
@@ -39,6 +39,7 @@ import org.jetbrains.kotlin.ir.types.isInt
 import org.jetbrains.kotlin.ir.types.isNullable
 import org.jetbrains.kotlin.ir.types.isUInt
 import org.jetbrains.kotlin.ir.util.functions
+import org.jetbrains.kotlin.ir.util.isArrayOrPrimitiveArray
 import org.jetbrains.kotlin.ir.util.render
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.FqName
@@ -251,7 +252,7 @@ private fun IrBlockBodyBuilder.maybeFindArrayContentHashCodeFunction(
 ): IrSimpleFunctionSymbol? {
     val propertyClassifier = property.type.classifierOrFail
 
-    val isArray = with(context) { propertyClassifier.isArrayOrPrimitiveArray() }
+    val isArray = propertyClassifier.isArrayOrPrimitiveArray(context.irBuiltIns)
     if (!isArray) {
         messageCollector.reportErrorOnProperty(
             property = property,
@@ -288,7 +289,7 @@ private fun IrBlockBodyBuilder.findArrayContentDeepHashCodeFunction(
 private fun IrBlockBodyBuilder.getStandardHashCodeFunctionSymbol(
     classifier: IrClassifierSymbol?,
 ): IrSimpleFunctionSymbol = when {
-    with(context) { classifier.isArrayOrPrimitiveArray() } ->
+    classifier.isArrayOrPrimitiveArray(context.irBuiltIns) ->
         context.irBuiltIns.dataClassArrayMemberHashCodeSymbol
     classifier is IrClassSymbol ->
         getHashCodeFunctionForClass(classifier.owner)

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/toStringGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/toStringGeneration.kt
@@ -28,6 +28,7 @@ import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.types.classifierOrFail
 import org.jetbrains.kotlin.ir.types.classifierOrNull
 import org.jetbrains.kotlin.ir.types.isNullable
+import org.jetbrains.kotlin.ir.util.isArrayOrPrimitiveArray
 import org.jetbrains.kotlin.ir.util.render
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.FqName
@@ -82,7 +83,7 @@ internal fun IrBlockBodyBuilder.generateToStringMethodBody(
                 )
             }
 
-            with(context) { classifier.isArrayOrPrimitiveArray() } -> {
+            classifier.isArrayOrPrimitiveArray(context.irBuiltIns) -> {
                 irCallToStringFunction(
                     toStringFunctionSymbol = context.irBuiltIns.dataClassArrayMemberToStringSymbol,
                     value = propertyValue,
@@ -110,7 +111,7 @@ private fun IrBlockBodyBuilder.maybeFindArrayDeepToStringFunction(
 ): IrSimpleFunctionSymbol? {
     val propertyClassifier = property.type.classifierOrFail
 
-    val isArray = with(context) { propertyClassifier.isArrayOrPrimitiveArray() }
+    val isArray = propertyClassifier.isArrayOrPrimitiveArray(context.irBuiltIns)
     if (!isArray) {
         messageCollector.reportErrorOnProperty(
             property = property,


### PR DESCRIPTION
There is an identical function in the compiler.

https://github.com/JetBrains/kotlin/blob/v2.0.20/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/AdditionalIrUtils.kt#L22-L23