### PR TITLE
Disable progressive mode when using older language version

### DIFF
--- a/build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildPlugin.kt
+++ b/build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildPlugin.kt
@@ -32,7 +32,7 @@ class PokoBuildPlugin : Plugin<Project> {
 
     private fun commonKotlinConfiguration(project: Project) {
         project.tasks.withType(KotlinCompilationTask::class.java).configureEach {
-            compilerOptions.freeCompilerArgs.add("-progressive")
+            compilerOptions.progressiveMode.convention(true)
         }
     }
 

--- a/poko-tests-without-k2/build.gradle.kts
+++ b/poko-tests-without-k2/build.gradle.kts
@@ -9,7 +9,10 @@ plugins {
 }
 
 tasks.withType<KotlinCompile>().configureEach {
-  compilerOptions.languageVersion.set(KotlinVersion.KOTLIN_1_9)
+  compilerOptions {
+    languageVersion = KotlinVersion.KOTLIN_1_9
+    progressiveMode = false
+  }
 }
 
 val jvmToolchainVersion: Int? = System.getenv()["poko_tests_jvm_toolchain_version"]?.toInt()


### PR DESCRIPTION
Fixes this compiler warning:

```
w: '-progressive' is meaningful only for the latest language version (2.0), while this build uses 1.9
Compiler behavior in such mode is undefined; please, consider moving to the latest stable version or turning off progressive mode.
```