### PR TITLE
Re-add sample tests against 2.0.0 and 2.0.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        poko_sample_kotlin_version: [ 2.0.20, ~, 2.1.0-Beta2 ]
+        poko_sample_kotlin_version: [ 2.0.0, 2.0.10, 2.0.20, ~, 2.1.0-Beta2 ]
     env:
       poko_sample_kotlin_version: ${{ matrix.poko_sample_kotlin_version }}
     steps:

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCompilerPluginRegistrar.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCompilerPluginRegistrar.kt
@@ -6,6 +6,7 @@ import dev.drewhamilton.poko.BuildConfig.DEFAULT_POKO_ENABLED
 import dev.drewhamilton.poko.fir.PokoFirExtensionRegistrar
 import dev.drewhamilton.poko.ir.PokoIrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
+import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
@@ -27,7 +28,12 @@ public class PokoCompilerPluginRegistrar : CompilerPluginRegistrar() {
         val pokoAnnotationString = configuration.get(CompilerOptions.POKO_ANNOTATION, DEFAULT_POKO_ANNOTATION)
         val pokoAnnotationClassId = ClassId.fromString(pokoAnnotationString)
         val messageCollector = configuration.get(
-            CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY,
+            try {
+                CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY
+            } catch (noSuchFieldError: NoSuchFieldError) {
+                @Suppress("DEPRECATION") // TODO: Remove when support for 2.0.10 is dropped
+                CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY
+            },
             MessageCollector.NONE,
         )
 

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
@@ -189,6 +189,7 @@ internal class PokoMembersTransformer(
      * available. Provides forward compatibility with 2.0.20, which changes the constructor's
      * signature.
      */
+    // TODO: Revert to standard IrValueParameterSymbolImpl when support for 2.0.10 is dropped
     @Suppress("FunctionName") // Factory
     private fun IrValueParameterSymbolImplCompat(
         descriptor: ParameterDescriptor,

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
@@ -202,7 +202,8 @@ internal class PokoMembersTransformer(
             // Old constructor pre-2.0.20:
             val implClass = IrValueParameterSymbolImpl::class.java
             val newConstructor = implClass.constructors.single {
-                it.parameters.single().type == ParameterDescriptor::class.java
+                it.parameters.size == 1 &&
+                    it.parameters.single().type == ParameterDescriptor::class.java
             }
             return newConstructor.newInstance(
                 descriptor, // param: descriptor

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/equalsGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/equalsGeneration.kt
@@ -28,7 +28,6 @@ import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrProperty
 import org.jetbrains.kotlin.ir.expressions.IrBranch
 import org.jetbrains.kotlin.ir.expressions.IrExpression
-import org.jetbrains.kotlin.ir.expressions.impl.IrBranchImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrWhenImpl
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrClassifierSymbol
@@ -234,7 +233,14 @@ private fun IrBuilderWithScope.irIfThenReturnBool(
     condition: IrExpression,
 ): IrWhenImpl {
     val thenPart = if (bool) irReturnTrue() else irReturnFalse()
-    return IrWhenImpl(startOffset, endOffset, context.irBuiltIns.unitType, null).apply {
-        branches.add(IrBranchImpl(startOffset, endOffset, condition, thenPart))
+    return IrWhenImplCompat(startOffset, endOffset, context.irBuiltIns.unitType).apply {
+        branches.add(
+            IrBranchImplCompat(
+                startOffset = startOffset,
+                endOffset = endOffset,
+                condition = condition,
+                result = thenPart,
+            )
+        )
     }
 }

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/functionGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/functionGeneration.kt
@@ -54,6 +54,7 @@ internal fun IrFunction.receiver(): IrGetValue = IrGetValueImpl(dispatchReceiver
  * Invoke [IrGetValueImpl] via reflection if the known function is not available. Provides forward
  * compatibility with 2.0.20, which changes the constructor's signature.
  */
+// TODO: Revert to standard IrGetValueImpl when support for 2.0.10 is dropped
 context(IrBlockBodyBuilder)
 internal fun IrGetValueImpl(
     parameter: IrValueParameter,

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
@@ -351,6 +351,7 @@ private fun IrBlockBodyBuilder.irCallHashCodeFunction(
  * Instantiate an [IrVariableImpl]. Backward-compatible with Kotlin 2.0.0—which used a
  * constructor instead of a factory function—via reflection.
  */
+// TODO: Revert to standard IrVariableImpl when 2.0.10 support is dropped
 @Suppress("FunctionName", "SameParameterValue") // Factory
 private fun IrVariableImplCompat(
     startOffset: Int,
@@ -376,7 +377,6 @@ private fun IrVariableImplCompat(
         isLateinit = isLateinit,
     )
 } catch (noSuchMethodError: NoSuchMethodError) {
-    // TODO: Test whether this is the write exception type
     // Constructor pre-2.0.20:
     origin.javaClass.classLoader
         .loadClass("org.jetbrains.kotlin.ir.declarations.impl.IrVariableImpl")

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
@@ -27,7 +27,6 @@ import org.jetbrains.kotlin.ir.declarations.IrProperty
 import org.jetbrains.kotlin.ir.declarations.impl.IrVariableImpl
 import org.jetbrains.kotlin.ir.expressions.IrBranch
 import org.jetbrains.kotlin.ir.expressions.IrExpression
-import org.jetbrains.kotlin.ir.expressions.impl.IrBranchImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrWhenImpl
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrClassifierSymbol
@@ -137,8 +136,8 @@ private fun IrBuilderWithScope.irIfNullCompat(
     thenPart: IrExpression,
     elsePart: IrExpression,
 ): IrWhenImpl {
-    return IrWhenImpl(startOffset, endOffset, type, null).apply {
-        branches.add(IrBranchImpl(startOffset, endOffset, irEqualsNull(subject), thenPart))
+    return IrWhenImplCompat(startOffset, endOffset, type).apply {
+        branches.add(IrBranchImplCompat(startOffset, endOffset, irEqualsNull(subject), thenPart))
         branches.add(irElseBranch(elsePart))
     }
 }
@@ -376,7 +375,7 @@ private fun IrVariableImplCompat(
         isConst = isConst,
         isLateinit = isLateinit,
     )
-} catch (noSuchMethodError: NoSuchMethodError) {
+} catch (noClassDefFoundError: NoClassDefFoundError) {
     // Constructor pre-2.0.20:
     origin.javaClass.classLoader
         .loadClass("org.jetbrains.kotlin.ir.declarations.impl.IrVariableImpl")


### PR DESCRIPTION
The [fix](https://github.com/drewhamilton/Poko/pull/411#issuecomment-2420523314) that @JakeWharton found in #411 should allow compatibility with 2.0.0 to work after all.