### PR TITLE
Simplify cone type resolution in `PokoFirExtensionSessionComponent`

### DIFF
--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/PokoFirExtensionSessionComponent.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/PokoFirExtensionSessionComponent.kt
@@ -1,18 +1,12 @@
 package dev.drewhamilton.poko.fir
 
-import kotlin.contracts.ExperimentalContracts
-import kotlin.contracts.contract
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.FirDeclaration
 import org.jetbrains.kotlin.fir.expressions.FirAnnotation
 import org.jetbrains.kotlin.fir.extensions.FirExtensionSessionComponent
 import org.jetbrains.kotlin.fir.extensions.FirExtensionSessionComponent.Factory
-import org.jetbrains.kotlin.fir.types.ConeClassLikeType
-import org.jetbrains.kotlin.fir.types.ConeKotlinType
-import org.jetbrains.kotlin.fir.types.FirResolvedTypeRef
-import org.jetbrains.kotlin.fir.types.FirTypeRef
 import org.jetbrains.kotlin.fir.types.classId
-import org.jetbrains.kotlin.fir.types.coneTypeSafe
+import org.jetbrains.kotlin.fir.types.coneTypeOrNull
 import org.jetbrains.kotlin.name.ClassId
 
 internal class PokoFirExtensionSessionComponent(
@@ -26,31 +20,7 @@ internal class PokoFirExtensionSessionComponent(
     }
 
     private fun FirAnnotation.classId(): ClassId? {
-        val coneClassLikeType = try {
-            annotationTypeRef.coneTypeSafe<ConeClassLikeType>()
-        } catch (noSuchMethodError: NoSuchMethodError) {
-            val annotationTypeRef = annotationTypeRef
-            if (annotationTypeRef is FirResolvedTypeRef) {
-                // The `coneTypeSafe` inline function uses a getter that changes names from `type`
-                // to `coneType` in 2.1+, so we access the latter via reflection here:
-                FirResolvedTypeRef::class.java
-                    .methods
-                    .single { it.name == "getConeType" }
-                    .invoke(annotationTypeRef)
-                    as? ConeClassLikeType
-            } else {
-                null
-            }
-        }
-        return coneClassLikeType?.classId
-    }
-
-    @OptIn(ExperimentalContracts::class)
-    private inline fun <reified T : ConeKotlinType> FirTypeRef.coneTypeSafeReflection(): T? {
-        contract {
-            returnsNotNull() implies (this@coneTypeSafeReflection is FirResolvedTypeRef)
-        }
-        return (this as? FirResolvedTypeRef)?.type as? T
+        return annotationTypeRef.coneTypeOrNull?.classId
     }
 
     internal companion object {


### PR DESCRIPTION
This public val has been available for awhile and is compatible across Kotlin versions.