### PR TITLE
Delete reflection and workarounds used to support Kotlin 2.0.x

### DIFF
--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCompilerPluginRegistrar.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCompilerPluginRegistrar.kt
@@ -6,7 +6,6 @@ import dev.drewhamilton.poko.BuildConfig.DEFAULT_POKO_ENABLED
 import dev.drewhamilton.poko.fir.PokoFirExtensionRegistrar
 import dev.drewhamilton.poko.ir.PokoIrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
-import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
@@ -28,12 +27,7 @@ public class PokoCompilerPluginRegistrar : CompilerPluginRegistrar() {
         val pokoAnnotationString = configuration.get(CompilerOptions.POKO_ANNOTATION, DEFAULT_POKO_ANNOTATION)
         val pokoAnnotationClassId = ClassId.fromString(pokoAnnotationString)
         val messageCollector = configuration.get(
-            try {
-                CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY
-            } catch (noSuchFieldError: NoSuchFieldError) {
-                @Suppress("DEPRECATION") // TODO: Remove when support for 2.0.10 is dropped
-                CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY
-            },
+            CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY,
             MessageCollector.NONE,
         )
 


### PR DESCRIPTION
Kotlin 2.1.0 broke ABI compatibility with older Kotlin versions (see #245), so internal workarounds to maintain compatibility are no longer needed.