### PR TITLE
Fix warning for non-custom `@Poko.Skip` annotation

### DIFF
--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/PokoFirCheckersExtension.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/PokoFirCheckersExtension.kt
@@ -96,8 +96,12 @@ internal class PokoFirCheckersExtension(
         }
 
         private fun FirAnnotation.isNestedInDefaultPokoAnnotation(): Boolean {
-            return annotationTypeRef.coneTypeOrNull?.classId?.outerClassId?.asFqNameString() ==
-                DEFAULT_POKO_ANNOTATION
+            val outerFqName = annotationTypeRef.coneTypeOrNull!!.classId!!
+                .outerClassId!!
+                .asFqNameString()
+            return outerFqName == DEFAULT_POKO_ANNOTATION ||
+                // Multiplatform FqName has "." instead of "/" for package:
+                outerFqName.replace(".", "/") == DEFAULT_POKO_ANNOTATION
         }
     }
 


### PR DESCRIPTION
During multiplatform compilation, the experimental feature warning was logged even though the opt-in annotation was already in use. Apparently multiplatform `FqName`s use `.` instead of `/`.