### PR TITLE
Move single-use FIR annotation matching

### DIFF
--- a/build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildPlugin.kt
+++ b/build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildPlugin.kt
@@ -107,7 +107,6 @@ class PokoBuildPlugin : Plugin<Project> {
                 buildConfigField("COMPILER_PLUGIN_ARTIFACT", "poko-compiler-plugin")
                 buildConfigField("DEFAULT_POKO_ENABLED", true)
                 buildConfigField("DEFAULT_POKO_ANNOTATION", "dev/drewhamilton/poko/Poko")
-                buildConfigField("SKIP_ANNOTATION_SHORT_NAME", "Skip")
             }
         }
     }

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoAnnotationNames.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoAnnotationNames.kt
@@ -1,0 +1,8 @@
+package dev.drewhamilton.poko
+
+import org.jetbrains.kotlin.name.Name
+
+internal object PokoAnnotationNames {
+    val ReadArrayContent = Name.identifier("ReadArrayContent")
+    val Skip = Name.identifier("Skip")
+}

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/PokoFirExtensionSessionComponent.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/PokoFirExtensionSessionComponent.kt
@@ -1,38 +1,18 @@
 package dev.drewhamilton.poko.fir
 
-import dev.drewhamilton.poko.BuildConfig.SKIP_ANNOTATION_SHORT_NAME
+import dev.drewhamilton.poko.PokoAnnotationNames
 import org.jetbrains.kotlin.fir.FirSession
-import org.jetbrains.kotlin.fir.declarations.FirDeclaration
-import org.jetbrains.kotlin.fir.expressions.FirAnnotation
 import org.jetbrains.kotlin.fir.extensions.FirExtensionSessionComponent
 import org.jetbrains.kotlin.fir.extensions.FirExtensionSessionComponent.Factory
-import org.jetbrains.kotlin.fir.types.classId
-import org.jetbrains.kotlin.fir.types.coneTypeOrNull
 import org.jetbrains.kotlin.name.ClassId
-import org.jetbrains.kotlin.name.Name
 
 internal class PokoFirExtensionSessionComponent(
     session: FirSession,
-    private val pokoAnnotation: ClassId,
+    internal val pokoAnnotation: ClassId,
 ) : FirExtensionSessionComponent(session) {
-    fun pokoAnnotation(declaration: FirDeclaration): FirAnnotation? {
-        return declaration.annotations.firstOrNull { firAnnotation ->
-            firAnnotation.classId() == pokoAnnotation
-        }
-    }
 
-    fun pokoSkipAnnotation(declaration: FirDeclaration): FirAnnotation? {
-        val skipAnnotation = pokoAnnotation.createNestedClassId(
-            name = Name.identifier(SKIP_ANNOTATION_SHORT_NAME),
-        )
-        return declaration.annotations.firstOrNull { firAnnotation ->
-            firAnnotation.classId() == skipAnnotation
-        }
-    }
-
-    private fun FirAnnotation.classId(): ClassId? {
-        return annotationTypeRef.coneTypeOrNull?.classId
-    }
+    internal val pokoSkipAnnotation: ClassId =
+        pokoAnnotation.createNestedClassId(PokoAnnotationNames.Skip)
 
     internal companion object {
         internal fun getFactory(pokoAnnotation: ClassId): Factory {

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
@@ -1,6 +1,6 @@
 package dev.drewhamilton.poko.ir
 
-import dev.drewhamilton.poko.BuildConfig.SKIP_ANNOTATION_SHORT_NAME
+import dev.drewhamilton.poko.PokoAnnotationNames
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
@@ -134,9 +134,7 @@ internal class PokoMembersTransformer(
             }
             .filter {
                 !it.hasAnnotation(
-                    classId = ClassId.fromString(
-                        string = "${pokoAnnotationName}.$SKIP_ANNOTATION_SHORT_NAME"
-                    ),
+                    classId = pokoAnnotationName.createNestedClassId(PokoAnnotationNames.Skip),
                 )
             }
         if (properties.isEmpty()) {

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/functionGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/functionGeneration.kt
@@ -1,5 +1,6 @@
 package dev.drewhamilton.poko.ir
 
+import dev.drewhamilton.poko.PokoAnnotationNames
 import org.jetbrains.kotlin.builtins.PrimitiveType
 import org.jetbrains.kotlin.ir.builders.IrBlockBodyBuilder
 import org.jetbrains.kotlin.ir.builders.IrGeneratorContextInterface
@@ -25,7 +26,6 @@ import org.jetbrains.kotlin.ir.util.isAnnotationClass
 import org.jetbrains.kotlin.ir.util.isInterface
 import org.jetbrains.kotlin.ir.util.render
 import org.jetbrains.kotlin.name.ClassId
-import org.jetbrains.kotlin.name.Name
 
 /**
  * The type of an [IrProperty].
@@ -62,7 +62,7 @@ internal fun IrBlockBodyBuilder.IrGetValueImpl(
 internal fun IrProperty.hasReadArrayContentAnnotation(
     pokoAnnotation: ClassId,
 ): Boolean = hasAnnotation(
-    classId = pokoAnnotation.createNestedClassId(Name.identifier("ReadArrayContent")),
+    classId = pokoAnnotation.createNestedClassId(PokoAnnotationNames.ReadArrayContent),
 )
 
 /**


### PR DESCRIPTION
From `PokoFirExtensionSessionComponent` to `PokoFirCheckersExtension`.

These signatures are kind of specific to the call-site, so it makes more sense to expose the annotation names directly so different FIR consumers can use them as needed.

Also remove "Skip" from BuildConfig since it's not needed by multiple modules.