### PR TITLE
Kotlin 2.1.20-Beta1 support via reflection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        poko_sample_kotlin_version: [ ~ ]
+        poko_sample_kotlin_version: [ ~, 2.1.20-Beta1 ]
     env:
       poko_sample_kotlin_version: ${{ matrix.poko_sample_kotlin_version }}
     steps:

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/compat.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/compat.kt
@@ -1,0 +1,55 @@
+package dev.drewhamilton.poko.ir
+
+import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
+import org.jetbrains.kotlin.ir.builders.irCall
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrStatementOrigin
+import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.types.IrType
+
+/**
+ * Alias for [irCall] from 2.1.0 – 2.1.20.
+ */
+@OptIn(UnsafeDuringIrConstructionAPI::class)
+internal fun IrBuilderWithScope.irCallCompat(
+    callee: IrSimpleFunctionSymbol,
+    type: IrType,
+    valueArgumentsCount: Int = callee.owner.valueParameters.size,
+    typeArgumentsCount: Int = callee.owner.typeParameters.size,
+    origin: IrStatementOrigin? = null,
+): IrCall {
+    return try {
+        // 2.1.0:
+        irCall(
+            callee = callee,
+            type = type,
+            valueArgumentsCount = valueArgumentsCount,
+            typeArgumentsCount = typeArgumentsCount,
+            origin = origin,
+        )
+    } catch (noSuchMethodError: NoSuchMethodError) {
+        // TODO: Flip order when 2.1.20 is the compile version
+        // https://github.com/JetBrains/kotlin/blob/v2.1.20-Beta1/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/builders/ExpressionHelpers.kt#L240
+        javaClass.classLoader.loadClass("org.jetbrains.kotlin.ir.builders.ExpressionHelpersKt")
+            .methods
+            .single { function ->
+                function.name == "irCall" &&
+                    function.parameters.map { it.type } == listOf(
+                        IrBuilderWithScope::class.java, // extension receiver
+                        IrSimpleFunctionSymbol::class.java, // callee
+                        IrType::class.java, // type
+                        Int::class.java, // typeArgumentsCount
+                        IrStatementOrigin::class.java, // origin
+                    )
+            }
+            .invoke(
+                null, // static invocation
+                this, // extension receiver
+                callee, // param: callee
+                type, // param: type
+                typeArgumentsCount, // param: type
+                origin, // param: origin
+            ) as IrCall
+    }
+}

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/equalsGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/equalsGeneration.kt
@@ -7,7 +7,6 @@ import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.ir.builders.IrBlockBodyBuilder
 import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
 import org.jetbrains.kotlin.ir.builders.irBranch
-import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irElseBranch
 import org.jetbrains.kotlin.ir.builders.irEqeqeq
 import org.jetbrains.kotlin.ir.builders.irEquals
@@ -195,7 +194,7 @@ private fun IrBuilderWithScope.irCallContentDeepEquals(
     receiver: IrExpression,
     argument: IrExpression,
 ): IrExpression {
-    return irCall(
+    return irCallCompat(
         callee = findContentDeepEqualsFunctionSymbol(context, classifier),
         type = context.irBuiltIns.booleanType,
         valueArgumentsCount = 1,

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
@@ -243,7 +243,7 @@ private fun IrBlockBodyBuilder.irArrayTypeCheckAndContentDeepHashCodeBranch(
     val type = classSymbol.createArrayType(context)
     return irBranch(
         condition = irIs(value, type),
-        result = irCall(
+        result = irCallCompat(
             callee = findArrayContentDeepHashCodeFunction(context, classSymbol),
             type = context.irBuiltIns.intType,
         ).apply {
@@ -336,7 +336,7 @@ private fun IrBlockBodyBuilder.irCallHashCodeFunction(
     val (hasDispatchReceiver, hasExtensionReceiver) = with(hashCodeFunctionSymbol.owner) {
         (dispatchReceiverParameter != null) to (extensionReceiverParameter != null)
     }
-    return irCall(
+    return irCallCompat(
         callee = hashCodeFunctionSymbol,
         type = context.irBuiltIns.intType,
         valueArgumentsCount = if (hasDispatchReceiver || hasExtensionReceiver) 0 else 1,

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/toStringGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/toStringGeneration.kt
@@ -5,7 +5,6 @@ import org.jetbrains.kotlin.builtins.PrimitiveType
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.ir.builders.IrBlockBodyBuilder
 import org.jetbrains.kotlin.ir.builders.irBranch
-import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irConcat
 import org.jetbrains.kotlin.ir.builders.irElseBranch
 import org.jetbrains.kotlin.ir.builders.irGetField
@@ -212,7 +211,7 @@ private fun IrBlockBodyBuilder.irCallToStringFunction(
     toStringFunctionSymbol: IrSimpleFunctionSymbol,
     value: IrExpression,
 ): IrExpression {
-    return irCall(
+    return irCallCompat(
         callee = toStringFunctionSymbol,
         type = context.irBuiltIns.stringType,
     ).apply {


### PR DESCRIPTION
Addresses the stacktrace filed in #455 and adds sample testing for the new beta version.