### PR TITLE
Generate Poko function declarations in FIR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,24 @@ jobs:
           -Dorg.gradle.project.pokoTests.jvmToolchainVersion=${{ matrix.poko_tests_jvm_toolchain_version }}
           -Dorg.gradle.project.pokoTests.compileMode=WITHOUT_K2
 
+  test-fir-generation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Install JDK ${{ matrix.poko_tests_jvm_toolchain_version }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 22
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Test
+        run: ./gradlew :poko-tests:build --stacktrace -Dorg.gradle.project.pokoTests.compileMode=FIR_GENERATION_ENABLED
+
   build-sample:
     runs-on: ubuntu-latest
     needs: build

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCompilerPluginRegistrar.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCompilerPluginRegistrar.kt
@@ -54,7 +54,7 @@ public class PokoCompilerPluginRegistrar : CompilerPluginRegistrar() {
             firDeclarationGenerationPluginValue?.toBoolean()?.also {
                 messageCollector.report(
                     severity = CompilerMessageSeverity.WARNING,
-                    message = "$firDeclarationGenerationPluginArg resolved to $it. " +
+                    message = "<$firDeclarationGenerationPluginArg> resolved to $it. " +
                         "This experimental flag may disappear at any time.",
                 )
             } ?: false

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoFunction.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoFunction.kt
@@ -1,0 +1,15 @@
+package dev.drewhamilton.poko
+
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.util.OperatorNameConventions
+
+/**
+ * Exhaustive representation of all functions Poko generates.
+ */
+internal enum class PokoFunction(
+    val functionName: Name,
+) {
+    Equals(OperatorNameConventions.EQUALS),
+    HashCode(OperatorNameConventions.HASH_CODE),
+    ToString(OperatorNameConventions.TO_STRING),
+}

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/PokoFirDeclarationGenerationExtension.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/PokoFirDeclarationGenerationExtension.kt
@@ -1,0 +1,90 @@
+package dev.drewhamilton.poko.fir
+
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
+import org.jetbrains.kotlin.fir.extensions.FirDeclarationGenerationExtension
+import org.jetbrains.kotlin.fir.extensions.FirDeclarationPredicateRegistrar
+import org.jetbrains.kotlin.fir.extensions.MemberGenerationContext
+import org.jetbrains.kotlin.fir.extensions.predicate.LookupPredicate
+import org.jetbrains.kotlin.fir.extensions.predicateBasedProvider
+import org.jetbrains.kotlin.fir.plugin.createMemberFunction
+import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
+import org.jetbrains.kotlin.name.CallableId
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.util.OperatorNameConventions
+import org.jetbrains.kotlin.utils.addToStdlib.runIf
+
+internal class PokoFirDeclarationGenerationExtension(
+    session: FirSession,
+) : FirDeclarationGenerationExtension(session) {
+    private val pokoAnnotation by lazy {
+        session.pokoFirExtensionSessionComponent.pokoAnnotation
+    }
+
+    private val pokoAnnotationPredicate by lazy {
+        LookupPredicate.create {
+            annotated(pokoAnnotation.asSingleFqName())
+        }
+    }
+
+    /**
+     * Pairs of <Poko.Builder ClassId, outer class Symbol>.
+     */
+    private val pokoClasses by lazy {
+        session.predicateBasedProvider.getSymbolsByPredicate(pokoAnnotationPredicate)
+            .filterIsInstance<FirRegularClassSymbol>()
+    }
+
+    override fun FirDeclarationPredicateRegistrar.registerPredicates() {
+        register(pokoAnnotationPredicate)
+    }
+
+    override fun getCallableNamesForClass(
+        classSymbol: FirClassSymbol<*>,
+        context: MemberGenerationContext,
+    ): Set<Name> = when {
+        classSymbol in pokoClasses -> setOf(/*EqualsName, HashCodeName,*/ ToStringName)
+        else -> emptySet()
+    }
+
+    override fun generateFunctions(
+        callableId: CallableId,
+        context: MemberGenerationContext?
+    ): List<FirNamedFunctionSymbol> {
+        val owner = context?.owner ?: return emptyList()
+
+        val callableName = callableId.callableName
+        val function = when (callableName) {
+            ToStringName -> runIf(!owner.hasDeclaredToStringFunction()) {
+                createToStringFunction(owner)
+            }
+
+            else -> null
+        }
+        return function?.let { listOf(it.symbol) } ?: emptyList()
+    }
+
+    private fun FirClassSymbol<*>.hasDeclaredToStringFunction(): Boolean {
+        return declarationSymbols
+            .filterIsInstance<FirNamedFunctionSymbol>()
+            .any { it.name == ToStringName && it.valueParameterSymbols.isEmpty() }
+    }
+
+    // TODO: Needs override marker?
+    private fun createToStringFunction(
+        owner: FirClassSymbol<*>,
+    ): FirSimpleFunction = createMemberFunction(
+        owner = owner,
+        key = PokoKey,
+        name = ToStringName,
+        returnType = session.builtinTypes.stringType.coneType,
+    )
+
+    private companion object {
+        private val EqualsName = OperatorNameConventions.EQUALS
+        private val HashCodeName = OperatorNameConventions.HASH_CODE
+        private val ToStringName = OperatorNameConventions.TO_STRING
+    }
+}

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/PokoFirDeclarationGenerationExtension.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/PokoFirDeclarationGenerationExtension.kt
@@ -62,6 +62,10 @@ internal class PokoFirDeclarationGenerationExtension(
                 createEqualsFunction(owner)
             }
 
+            HashCodeName -> runIf(!owner.hasDeclaredHashCodeFunction()) {
+                createHashCodeFunction(owner)
+            }
+
             ToStringName -> runIf(!owner.hasDeclaredToStringFunction()) {
                 createToStringFunction(owner)
             }
@@ -99,6 +103,27 @@ internal class PokoFirDeclarationGenerationExtension(
             key = PokoKey,
         )
     }
+    //endregion
+
+    //region hashCode
+    private fun FirClassSymbol<*>.hasDeclaredHashCodeFunction(): Boolean {
+        return declarationSymbols
+            .filterIsInstance<FirNamedFunctionSymbol>()
+            .any {
+                !it.isExtension &&
+                    it.name == HashCodeName &&
+                    it.valueParameterSymbols.isEmpty()
+            }
+    }
+
+    private fun createHashCodeFunction(
+        owner: FirClassSymbol<*>,
+    ): FirSimpleFunction = createMemberFunction(
+        owner = owner,
+        key = PokoKey,
+        name = HashCodeName,
+        returnType = session.builtinTypes.intType.coneType,
+    )
     //endregion
 
     //region toString

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/PokoFirExtensionRegistrar.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/PokoFirExtensionRegistrar.kt
@@ -5,10 +5,13 @@ import org.jetbrains.kotlin.name.ClassId
 
 internal class PokoFirExtensionRegistrar(
     private val pokoAnnotation: ClassId,
+    private val declarationGeneration: Boolean,
 ) : FirExtensionRegistrar() {
     override fun ExtensionRegistrarContext.configurePlugin() {
         +PokoFirExtensionSessionComponent.getFactory(pokoAnnotation)
         +::PokoFirCheckersExtension
-        +::PokoFirDeclarationGenerationExtension
+        if (declarationGeneration) {
+            +::PokoFirDeclarationGenerationExtension
+        }
     }
 }

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/PokoFirExtensionRegistrar.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/PokoFirExtensionRegistrar.kt
@@ -9,5 +9,6 @@ internal class PokoFirExtensionRegistrar(
     override fun ExtensionRegistrarContext.configurePlugin() {
         +PokoFirExtensionSessionComponent.getFactory(pokoAnnotation)
         +::PokoFirCheckersExtension
+        +::PokoFirDeclarationGenerationExtension
     }
 }

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/PokoKey.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/PokoKey.kt
@@ -1,0 +1,7 @@
+package dev.drewhamilton.poko.fir
+
+import org.jetbrains.kotlin.GeneratedDeclarationKey
+
+internal object PokoKey : GeneratedDeclarationKey() {
+    override fun toString() = "FirPoko"
+}

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoFunctionBodyFiller.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoFunctionBodyFiller.kt
@@ -1,0 +1,77 @@
+package dev.drewhamilton.poko.ir
+
+import dev.drewhamilton.poko.fir.PokoKey
+import org.jetbrains.kotlin.GeneratedDeclarationKey
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
+import org.jetbrains.kotlin.backend.common.lower.FlattenStringConcatenationLowering.Companion.isToString
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.ir.IrElement
+import org.jetbrains.kotlin.ir.builders.irBlockBody
+import org.jetbrains.kotlin.ir.declarations.IrDeclaration
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin.GeneratedByPlugin
+import org.jetbrains.kotlin.ir.declarations.IrFile
+import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.util.parentAsClass
+import org.jetbrains.kotlin.ir.visitors.IrElementVisitorVoid
+import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
+import org.jetbrains.kotlin.name.ClassId
+
+@OptIn(UnsafeDuringIrConstructionAPI::class)
+internal class PokoFunctionBodyFiller(
+    private val pokoAnnotation: ClassId,
+    private val context: IrPluginContext,
+    private val messageCollector: MessageCollector,
+) : IrElementVisitorVoid {
+
+    override fun visitSimpleFunction(declaration: IrSimpleFunction) {
+        val origin = declaration.origin
+        if (origin !is GeneratedByPlugin || !interestedIn(origin.pluginKey)) {
+            return
+        }
+
+        require(declaration.body == null)
+
+        val pokoClass = declaration.parentAsClass
+        val pokoProperties = pokoClass.pokoProperties(pokoAnnotation).also {
+            if (it.isEmpty()) {
+                messageCollector.log("No primary constructor properties")
+                messageCollector.reportErrorOnClass(
+                    irClass = pokoClass,
+                    message = "Poko class primary constructor must have at least one not-skipped property",
+                )
+            }
+        }
+        declaration.body = when {
+            declaration.isToString -> DeclarationIrBuilder(
+                generatorContext = context,
+                symbol = declaration.symbol,
+            ).irBlockBody {
+                generateToStringMethodBody(
+                    pokoAnnotation = pokoAnnotation,
+                    context = this@PokoFunctionBodyFiller.context,
+                    irClass = pokoClass,
+                    functionDeclaration = declaration,
+                    classProperties = pokoProperties,
+                    messageCollector = messageCollector,
+                )
+            }
+            else -> null
+        }
+    }
+
+    private fun interestedIn(
+        key: GeneratedDeclarationKey?,
+    ): Boolean {
+        return key == PokoKey
+    }
+
+    override fun visitElement(element: IrElement) {
+        when (element) {
+            is IrDeclaration, is IrFile, is IrModuleFragment -> element.acceptChildrenVoid(this)
+            else -> Unit
+        }
+    }
+}

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoFunctionBodyFiller.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoFunctionBodyFiller.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.util.isEquals
+import org.jetbrains.kotlin.ir.util.isHashCode
 import org.jetbrains.kotlin.ir.util.isToString
 import org.jetbrains.kotlin.ir.util.parentAsClass
 import org.jetbrains.kotlin.ir.visitors.IrElementVisitorVoid
@@ -35,7 +36,7 @@ internal class PokoFunctionBodyFiller(
 
         require(declaration.body == null)
 
-        if (!(declaration.isEquals() || declaration.isToString())) {
+        if (!(declaration.isEquals() || declaration.isHashCode() || declaration.isToString())) {
             return
         }
 
@@ -59,6 +60,14 @@ internal class PokoFunctionBodyFiller(
                     pokoAnnotation = pokoAnnotation,
                     context = this@PokoFunctionBodyFiller.context,
                     irClass = pokoClass,
+                    functionDeclaration = declaration,
+                    classProperties = pokoProperties,
+                    messageCollector = messageCollector,
+                )
+
+                declaration.isHashCode() -> generateHashCodeMethodBody(
+                    pokoAnnotation = pokoAnnotation,
+                    context = this@PokoFunctionBodyFiller.context,
                     functionDeclaration = declaration,
                     classProperties = pokoProperties,
                     messageCollector = messageCollector,

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoIrGenerationExtension.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoIrGenerationExtension.kt
@@ -6,6 +6,7 @@ import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.cli.common.messages.MessageUtil
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
 import org.jetbrains.kotlin.js.resolve.diagnostics.findPsi
 import org.jetbrains.kotlin.name.ClassId
 
@@ -26,6 +27,13 @@ internal class PokoIrGenerationExtension(
             messageCollector = messageCollector,
         )
         moduleFragment.transform(pokoMembersTransformer, null)
+
+        val bodyFiller = PokoFunctionBodyFiller(
+            pokoAnnotation = pokoAnnotationName,
+            context = pluginContext,
+            messageCollector = messageCollector,
+        )
+        moduleFragment.acceptChildrenVoid(bodyFiller)
     }
 
     private fun IrModuleFragment.reportError(message: String) {

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoIrGenerationExtension.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoIrGenerationExtension.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.name.ClassId
 
 internal class PokoIrGenerationExtension(
     private val pokoAnnotationName: ClassId,
+    private val firDeclarationGeneration: Boolean,
     private val messageCollector: MessageCollector
 ) : IrGenerationExtension {
 
@@ -21,7 +22,10 @@ internal class PokoIrGenerationExtension(
             return
         }
 
-        if (pluginContext.afterK2) {
+        if (firDeclarationGeneration) {
+            require(pluginContext.afterK2) {
+                "Cannot use experimental Poko FIR generation with K2 disabled"
+            }
             val bodyFiller = PokoFunctionBodyFiller(
                 pokoAnnotation = pokoAnnotationName,
                 context = pluginContext,

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoIrGenerationExtension.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoIrGenerationExtension.kt
@@ -21,19 +21,21 @@ internal class PokoIrGenerationExtension(
             return
         }
 
-        val pokoMembersTransformer = PokoMembersTransformer(
-            pokoAnnotationName = pokoAnnotationName,
-            pluginContext = pluginContext,
-            messageCollector = messageCollector,
-        )
-        moduleFragment.transform(pokoMembersTransformer, null)
-
-        val bodyFiller = PokoFunctionBodyFiller(
-            pokoAnnotation = pokoAnnotationName,
-            context = pluginContext,
-            messageCollector = messageCollector,
-        )
-        moduleFragment.acceptChildrenVoid(bodyFiller)
+        if (pluginContext.afterK2) {
+            val bodyFiller = PokoFunctionBodyFiller(
+                pokoAnnotation = pokoAnnotationName,
+                context = pluginContext,
+                messageCollector = messageCollector,
+            )
+            moduleFragment.acceptChildrenVoid(bodyFiller)
+        } else {
+            val pokoMembersTransformer = PokoMembersTransformer(
+                pokoAnnotationName = pokoAnnotationName,
+                pluginContext = pluginContext,
+                messageCollector = messageCollector,
+            )
+            moduleFragment.transform(pokoMembersTransformer, null)
+        }
     }
 
     private fun IrModuleFragment.reportError(message: String) {

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoIrGenerationExtension.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoIrGenerationExtension.kt
@@ -23,8 +23,11 @@ internal class PokoIrGenerationExtension(
         }
 
         if (firDeclarationGeneration) {
-            require(pluginContext.afterK2) {
-                "Cannot use experimental Poko FIR generation with K2 disabled"
+            if (!pluginContext.afterK2) {
+                messageCollector.report(
+                    severity = CompilerMessageSeverity.ERROR,
+                    message = "Cannot use experimental Poko FIR generation with K2 disabled"
+                )
             }
             val bodyFiller = PokoFunctionBodyFiller(
                 pokoAnnotation = pokoAnnotationName,

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
@@ -37,7 +37,7 @@ internal class PokoMembersTransformer(
         val declarationParent = declaration.parent
         if (declarationParent is IrClass && declarationParent.isPokoClass() && declaration.isFakeOverride) {
             when {
-                declaration.isEquals() -> declaration.convertToGenerated { properties ->
+                !pluginContext.afterK2 && declaration.isEquals() -> declaration.convertToGenerated { properties ->
                     generateEqualsMethodBody(
                         pokoAnnotation = pokoAnnotationName,
                         context = pluginContext,

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
@@ -58,7 +58,8 @@ internal class PokoMembersTransformer(
                     )
                 }
 
-                declaration.isToString() -> declaration.convertToGenerated { properties ->
+                // TODO: Outline K2 check to PokoIrGenerationExtension once this class is only used for K1
+                !pluginContext.afterK2 && declaration.isToString() -> declaration.convertToGenerated { properties ->
                     generateToStringMethodBody(
                         pokoAnnotation = pokoAnnotationName,
                         context = pluginContext,

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
@@ -48,7 +48,7 @@ internal class PokoMembersTransformer(
                     )
                 }
 
-                declaration.isHashCode() -> declaration.convertToGenerated { properties ->
+                !pluginContext.afterK2 && declaration.isHashCode() -> declaration.convertToGenerated { properties ->
                     generateHashCodeMethodBody(
                         pokoAnnotation = pokoAnnotationName,
                         context = pluginContext,

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
@@ -25,6 +25,9 @@ import org.jetbrains.kotlin.ir.util.isToString
 import org.jetbrains.kotlin.ir.util.primaryConstructor
 import org.jetbrains.kotlin.name.ClassId
 
+/**
+ * For use only with the K1 compiler. K2 uses [PokoFunctionBodyFiller].
+ */
 internal class PokoMembersTransformer(
     private val pokoAnnotationName: ClassId,
     private val pluginContext: IrPluginContext,
@@ -37,7 +40,7 @@ internal class PokoMembersTransformer(
         val declarationParent = declaration.parent
         if (declarationParent is IrClass && declarationParent.isPokoClass() && declaration.isFakeOverride) {
             when {
-                !pluginContext.afterK2 && declaration.isEquals() -> declaration.convertToGenerated { properties ->
+                declaration.isEquals() -> declaration.convertToGenerated { properties ->
                     generateEqualsMethodBody(
                         pokoAnnotation = pokoAnnotationName,
                         context = pluginContext,
@@ -48,7 +51,7 @@ internal class PokoMembersTransformer(
                     )
                 }
 
-                !pluginContext.afterK2 && declaration.isHashCode() -> declaration.convertToGenerated { properties ->
+                declaration.isHashCode() -> declaration.convertToGenerated { properties ->
                     generateHashCodeMethodBody(
                         pokoAnnotation = pokoAnnotationName,
                         context = pluginContext,
@@ -58,8 +61,7 @@ internal class PokoMembersTransformer(
                     )
                 }
 
-                // TODO: Outline K2 check to PokoIrGenerationExtension once this class is only used for K1
-                !pluginContext.afterK2 && declaration.isToString() -> declaration.convertToGenerated { properties ->
+                declaration.isToString() -> declaration.convertToGenerated { properties ->
                     generateToStringMethodBody(
                         pokoAnnotation = pokoAnnotationName,
                         context = pluginContext,

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
@@ -1,13 +1,10 @@
 package dev.drewhamilton.poko.ir
 
-import dev.drewhamilton.poko.PokoAnnotationNames
-import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.descriptors.impl.LazyClassReceiverParameterDescriptor
-import org.jetbrains.kotlin.fir.backend.FirMetadataSource
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
 import org.jetbrains.kotlin.ir.builders.IrBlockBodyBuilder
@@ -26,10 +23,7 @@ import org.jetbrains.kotlin.ir.util.isFakeOverride
 import org.jetbrains.kotlin.ir.util.isHashCode
 import org.jetbrains.kotlin.ir.util.isToString
 import org.jetbrains.kotlin.ir.util.primaryConstructor
-import org.jetbrains.kotlin.ir.util.properties
 import org.jetbrains.kotlin.name.ClassId
-import org.jetbrains.kotlin.psi.KtParameter
-import org.jetbrains.kotlin.resolve.source.getPsi
 
 internal class PokoMembersTransformer(
     private val pokoAnnotationName: ClassId,
@@ -119,24 +113,7 @@ internal class PokoMembersTransformer(
         generateFunctionBody: IrBlockBodyBuilder.(List<IrProperty>) -> Unit
     ) {
         val parent = parent as IrClass
-        val properties = parent.properties
-            .toList()
-            .filter {
-                val metadata = it.metadata
-                if (metadata is FirMetadataSource.Property) {
-                    // Using K2:
-                    metadata.fir.source?.kind is KtFakeSourceElementKind.PropertyFromParameter
-                } else {
-                    // Not using K2:
-                    @OptIn(ObsoleteDescriptorBasedAPI::class)
-                    it.symbol.descriptor.source.getPsi() is KtParameter
-                }
-            }
-            .filter {
-                !it.hasAnnotation(
-                    classId = pokoAnnotationName.createNestedClassId(PokoAnnotationNames.Skip),
-                )
-            }
+        val properties = parent.pokoProperties(pokoAnnotationName)
         if (properties.isEmpty()) {
             messageCollector.log("No primary constructor properties")
             messageCollector.reportErrorOnClass(

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/irHelpers.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/irHelpers.kt
@@ -1,0 +1,38 @@
+package dev.drewhamilton.poko.ir
+
+import dev.drewhamilton.poko.PokoAnnotationNames
+import org.jetbrains.kotlin.KtFakeSourceElementKind
+import org.jetbrains.kotlin.fir.backend.FirMetadataSource
+import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
+import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.declarations.IrProperty
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.util.hasAnnotation
+import org.jetbrains.kotlin.ir.util.properties
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.resolve.source.getPsi
+
+@UnsafeDuringIrConstructionAPI
+internal fun IrClass.pokoProperties(
+    pokoAnnotation: ClassId,
+): List<IrProperty> {
+    return properties
+        .toList()
+        .filter {
+            val metadata = it.metadata
+            if (metadata is FirMetadataSource.Property) {
+                // Using K2:
+                metadata.fir.source?.kind is KtFakeSourceElementKind.PropertyFromParameter
+            } else {
+                // Not using K2:
+                @OptIn(ObsoleteDescriptorBasedAPI::class)
+                it.symbol.descriptor.source.getPsi() is KtParameter
+            }
+        }
+        .filter {
+            !it.hasAnnotation(
+                classId = pokoAnnotation.createNestedClassId(PokoAnnotationNames.Skip),
+            )
+        }
+}

--- a/poko-tests/build.gradle.kts
+++ b/poko-tests/build.gradle.kts
@@ -10,6 +10,8 @@ plugins {
 
 val compileMode = findProperty("pokoTests.compileMode")
 when (compileMode) {
+  null -> Unit // Nothing to configure
+
   "WITHOUT_K2" -> {
     logger.lifecycle("Building :poko-tests without K2 (language level 1.9)")
     tasks.withType<KotlinCompile>().configureEach {
@@ -19,6 +21,22 @@ when (compileMode) {
       }
     }
   }
+
+  "FIR_GENERATION_ENABLED" -> {
+    logger.lifecycle("Building :poko-tests with FIR declaration generation enabled")
+    tasks.withType<KotlinCompile>().configureEach {
+      compilerOptions {
+        freeCompilerArgs.addAll(
+          listOf(
+            "-P",
+            "plugin:poko-compiler-plugin:pokoPluginArgs=poko.experimental.enableFirDeclarationGeneration=true",
+          ),
+        )
+      }
+    }
+  }
+
+  else -> throw IllegalArgumentException("Unknown pokoTests.compileMode: <$compileMode>")
 }
 
 val jvmToolchainVersion = (findProperty("pokoTests.jvmToolchainVersion") as? String)?.toInt()


### PR DESCRIPTION
Previously, we only modified code at the IR layer; finding the `Any.equals`, `Any.hashCode`, and `Any.toString` functions, modifying their dispatch receiver to the Poko class and generating the body. With this change, when K2 is enabled, we instead generate these function declarations for each Poko class in FIR, and then (still) fill in the body in IR. This should make it possible for theoretical FIR-based linters to recognize that Poko classes have implemented these functions.

This new approach is hidden behind an experimental flag, `poko.experimental.enableFirDeclarationGeneration`, and is disabled by default. It should not be used in production yet.

~~Incidentally, this diverges from data classes, which do not declare these functions in FIR. I'm not sure if this is an intentional choice or just a holdover from pre-FIR days.~~ Data classes declare these functions in FIR in a more complicated way than this in order to account for various possibilities in the superclass, like final overrides and `expect`/`actual` delarations. We'll have to mimic the resulting behavior before promoting this to default-enabled.