### PR TITLE
Add support for property-based plugin arguments

### DIFF
--- a/build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildPlugin.kt
+++ b/build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildPlugin.kt
@@ -105,8 +105,16 @@ class PokoBuildPlugin : Plugin<Project> {
                 buildConfigField("VERSION", project.pokoVersion)
                 buildConfigField("ANNOTATIONS_ARTIFACT", "poko-annotations")
                 buildConfigField("COMPILER_PLUGIN_ARTIFACT", "poko-compiler-plugin")
+
+                buildConfigField("POKO_ENABLED_OPTION_NAME", "enabled")
                 buildConfigField("DEFAULT_POKO_ENABLED", true)
+
+                buildConfigField("POKO_ANNOTATION_OPTION_NAME", "pokoAnnotation")
                 buildConfigField("DEFAULT_POKO_ANNOTATION", "dev/drewhamilton/poko/Poko")
+
+                buildConfigField("POKO_PLUGIN_ARGS_OPTION_NAME", "pokoPluginArgs")
+                buildConfigField("POKO_PLUGIN_ARGS_LIST_DELIMITER", ';')
+                buildConfigField("POKO_PLUGIN_ARGS_ITEM_DELIMITER", '=')
             }
         }
     }

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/CompilerOptions.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/CompilerOptions.kt
@@ -3,7 +3,8 @@ package dev.drewhamilton.poko
 import org.jetbrains.kotlin.config.CompilerConfigurationKey
 
 internal object CompilerOptions {
-    val ENABLED = CompilerConfigurationKey<Boolean>("enabled")
-    val POKO_ANNOTATION = CompilerConfigurationKey<String>("pokoAnnotation")
-    val POKO_PLUGIN_ARGS = CompilerConfigurationKey<List<String>>("pokoPluginArgs")
+    val ENABLED = CompilerConfigurationKey<Boolean>(BuildConfig.POKO_ENABLED_OPTION_NAME)
+    val POKO_ANNOTATION = CompilerConfigurationKey<String>(BuildConfig.POKO_ANNOTATION_OPTION_NAME)
+    val POKO_PLUGIN_ARGS =
+        CompilerConfigurationKey<List<String>>(BuildConfig.POKO_PLUGIN_ARGS_OPTION_NAME)
 }

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/CompilerOptions.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/CompilerOptions.kt
@@ -6,5 +6,5 @@ internal object CompilerOptions {
     val ENABLED = CompilerConfigurationKey<Boolean>(BuildConfig.POKO_ENABLED_OPTION_NAME)
     val POKO_ANNOTATION = CompilerConfigurationKey<String>(BuildConfig.POKO_ANNOTATION_OPTION_NAME)
     val POKO_PLUGIN_ARGS =
-        CompilerConfigurationKey<List<String>>(BuildConfig.POKO_PLUGIN_ARGS_OPTION_NAME)
+        CompilerConfigurationKey<Map<String, String>>(BuildConfig.POKO_PLUGIN_ARGS_OPTION_NAME)
 }

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/CompilerOptions.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/CompilerOptions.kt
@@ -5,4 +5,5 @@ import org.jetbrains.kotlin.config.CompilerConfigurationKey
 internal object CompilerOptions {
     val ENABLED = CompilerConfigurationKey<Boolean>("enabled")
     val POKO_ANNOTATION = CompilerConfigurationKey<String>("pokoAnnotation")
+    val POKO_PLUGIN_ARGS = CompilerConfigurationKey<List<String>>("pokoPluginArgs")
 }

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCommandLineProcessor.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCommandLineProcessor.kt
@@ -50,7 +50,7 @@ public class PokoCommandLineProcessor : CommandLineProcessor {
                     .associate { arg ->
                         arg.split(BuildConfig.POKO_PLUGIN_ARGS_ITEM_DELIMITER).let {
                             require(it.size == 2) {
-                                "Invalid syntax for ${it.first()}: " +
+                                "Invalid syntax for <${it.firstOrNull()}>: " +
                                     "must be in `key=value` property format"
                             }
                             it.first() to it.last()

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCommandLineProcessor.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCommandLineProcessor.kt
@@ -46,7 +46,16 @@ public class PokoCommandLineProcessor : CommandLineProcessor {
         CompilerOptions.POKO_PLUGIN_ARGS.toString() ->
             configuration.put(
                 CompilerOptions.POKO_PLUGIN_ARGS,
-                value.split(BuildConfig.POKO_PLUGIN_ARGS_LIST_DELIMITER),
+                value.split(BuildConfig.POKO_PLUGIN_ARGS_LIST_DELIMITER)
+                    .associate { arg ->
+                        arg.split(BuildConfig.POKO_PLUGIN_ARGS_ITEM_DELIMITER).let {
+                            require(it.size == 2) {
+                                "Invalid syntax for ${it.first()}: " +
+                                    "must be in `key=value` property format"
+                            }
+                            it.first() to it.last()
+                        }
+                    },
             )
         else ->
             throw IllegalArgumentException("Unknown plugin option: ${option.optionName}")

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCommandLineProcessor.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCommandLineProcessor.kt
@@ -44,7 +44,10 @@ public class PokoCommandLineProcessor : CommandLineProcessor {
         CompilerOptions.POKO_ANNOTATION.toString() ->
             configuration.put(CompilerOptions.POKO_ANNOTATION, value)
         CompilerOptions.POKO_PLUGIN_ARGS.toString() ->
-            configuration.put(CompilerOptions.POKO_PLUGIN_ARGS, value.split(','))
+            configuration.put(
+                CompilerOptions.POKO_PLUGIN_ARGS,
+                value.split(BuildConfig.POKO_PLUGIN_ARGS_LIST_DELIMITER),
+            )
         else ->
             throw IllegalArgumentException("Unknown plugin option: ${option.optionName}")
     }

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCommandLineProcessor.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCommandLineProcessor.kt
@@ -14,8 +14,24 @@ public class PokoCommandLineProcessor : CommandLineProcessor {
     override val pluginId: String = BuildConfig.COMPILER_PLUGIN_ARTIFACT
 
     override val pluginOptions: Collection<AbstractCliOption> = listOf(
-        CliOption(CompilerOptions.ENABLED.toString(), "<true|false>", "", required = false),
-        CliOption(CompilerOptions.POKO_ANNOTATION.toString(), "Annotation class name", "", required = false),
+        CliOption(
+            optionName = CompilerOptions.ENABLED.toString(),
+            valueDescription = "<true|false>",
+            description = "",
+            required = false,
+        ),
+        CliOption(
+            optionName = CompilerOptions.POKO_ANNOTATION.toString(),
+            valueDescription = "Annotation class name",
+            description = "",
+            required = false,
+        ),
+        CliOption(
+            optionName = CompilerOptions.POKO_PLUGIN_ARGS.toString(),
+            valueDescription = "",
+            description = "Additional Poko compiler plugin arguments",
+            required = false,
+        ),
     )
 
     override fun processOption(
@@ -23,8 +39,13 @@ public class PokoCommandLineProcessor : CommandLineProcessor {
         value: String,
         configuration: CompilerConfiguration
     ): Unit = when (option.optionName) {
-        CompilerOptions.ENABLED.toString() -> configuration.put(CompilerOptions.ENABLED, value.toBoolean())
-        CompilerOptions.POKO_ANNOTATION.toString() -> configuration.put(CompilerOptions.POKO_ANNOTATION, value)
-        else -> throw IllegalArgumentException("Unknown plugin option: ${option.optionName}")
+        CompilerOptions.ENABLED.toString() ->
+            configuration.put(CompilerOptions.ENABLED, value.toBoolean())
+        CompilerOptions.POKO_ANNOTATION.toString() ->
+            configuration.put(CompilerOptions.POKO_ANNOTATION, value)
+        CompilerOptions.POKO_PLUGIN_ARGS.toString() ->
+            configuration.put(CompilerOptions.POKO_PLUGIN_ARGS, value.split(','))
+        else ->
+            throw IllegalArgumentException("Unknown plugin option: ${option.optionName}")
     }
 }

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCompilerPluginRegistrar.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCompilerPluginRegistrar.kt
@@ -35,12 +35,7 @@ public class PokoCompilerPluginRegistrar : CompilerPluginRegistrar() {
             MessageCollector.NONE,
         )
 
-        val pokoPluginArgs = configuration.get(CompilerOptions.POKO_PLUGIN_ARGS, emptyList())
-            .associate { arg ->
-                arg.split(BuildConfig.POKO_PLUGIN_ARGS_ITEM_DELIMITER).let {
-                    it.first() to it.last()
-                }
-            }
+        val pokoPluginArgs = configuration.get(CompilerOptions.POKO_PLUGIN_ARGS, emptyMap())
         pokoPluginArgs.keys.forEach { pluginArgName ->
             if (!knownPokoPluginArgs.contains(pluginArgName)) {
                 messageCollector.report(

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCompilerPluginRegistrar.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCompilerPluginRegistrar.kt
@@ -37,7 +37,9 @@ public class PokoCompilerPluginRegistrar : CompilerPluginRegistrar() {
 
         val pokoPluginArgs = configuration.get(CompilerOptions.POKO_PLUGIN_ARGS, emptyList())
             .associate { arg ->
-                arg.split('=').let { it.first() to it.last() }
+                arg.split(BuildConfig.POKO_PLUGIN_ARGS_ITEM_DELIMITER).let {
+                    it.first() to it.last()
+                }
             }
         pokoPluginArgs.keys.forEach { pluginArgName ->
             if (!knownPokoPluginArgs.contains(pluginArgName)) {

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCompilerPluginRegistrar.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCompilerPluginRegistrar.kt
@@ -6,6 +6,7 @@ import dev.drewhamilton.poko.BuildConfig.DEFAULT_POKO_ENABLED
 import dev.drewhamilton.poko.fir.PokoFirExtensionRegistrar
 import dev.drewhamilton.poko.ir.PokoIrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
@@ -20,16 +21,29 @@ public class PokoCompilerPluginRegistrar : CompilerPluginRegistrar() {
 
     override val supportsK2: Boolean get() = true
 
+    private val knownPokoPluginArgs = emptySet<String>()
+
     override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
         if (!configuration.get(CompilerOptions.ENABLED, DEFAULT_POKO_ENABLED))
             return
 
         val pokoAnnotationString = configuration.get(CompilerOptions.POKO_ANNOTATION, DEFAULT_POKO_ANNOTATION)
         val pokoAnnotationClassId = ClassId.fromString(pokoAnnotationString)
+
         val messageCollector = configuration.get(
             CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY,
             MessageCollector.NONE,
         )
+
+        val pokoPluginArgs = configuration.get(CompilerOptions.POKO_PLUGIN_ARGS, emptyList())
+        pokoPluginArgs.forEach { pluginArg ->
+            if (!knownPokoPluginArgs.contains(pluginArg)) {
+                messageCollector.report(
+                    severity = CompilerMessageSeverity.WARNING,
+                    message = "Ignoring unknown Poko plugin arg: $pluginArg",
+                )
+            }
+        }
 
         IrGenerationExtension.registerExtension(
             PokoIrGenerationExtension(pokoAnnotationClassId, messageCollector)

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCompilerPluginRegistrar.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCompilerPluginRegistrar.kt
@@ -36,11 +36,14 @@ public class PokoCompilerPluginRegistrar : CompilerPluginRegistrar() {
         )
 
         val pokoPluginArgs = configuration.get(CompilerOptions.POKO_PLUGIN_ARGS, emptyList())
-        pokoPluginArgs.forEach { pluginArg ->
-            if (!knownPokoPluginArgs.contains(pluginArg)) {
+            .associate { arg ->
+                arg.split('=').let { it.first() to it.last() }
+            }
+        pokoPluginArgs.keys.forEach { pluginArgName ->
+            if (!knownPokoPluginArgs.contains(pluginArgName)) {
                 messageCollector.report(
                     severity = CompilerMessageSeverity.WARNING,
-                    message = "Ignoring unknown Poko plugin arg: $pluginArg",
+                    message = "Ignoring unknown Poko plugin arg: $pluginArgName",
                 )
             }
         }

--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
@@ -266,18 +266,13 @@ class PokoCompilerPluginTest(
 
         val commandLineProcessor = PokoCommandLineProcessor()
         commandLineProcessors = listOf(commandLineProcessor)
-        val standardPluginOptions = listOf(
+        pluginOptions = listOfNotNull(
             commandLineProcessor.option(CompilerOptions.ENABLED, true),
-            commandLineProcessor.option(CompilerOptions.POKO_ANNOTATION, pokoAnnotationName)
+            commandLineProcessor.option(CompilerOptions.POKO_ANNOTATION, pokoAnnotationName),
+            pokoPluginArgs?.let {
+                commandLineProcessor.option(CompilerOptions.POKO_PLUGIN_ARGS, it)
+            },
         )
-        pluginOptions = if (pokoPluginArgs == null) {
-            standardPluginOptions
-        } else {
-            standardPluginOptions + commandLineProcessor.option(
-                key = CompilerOptions.POKO_PLUGIN_ARGS,
-                value = pokoPluginArgs
-            )
-        }
     }
 
     private fun CommandLineProcessor.option(

--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
@@ -177,14 +177,35 @@ class PokoCompilerPluginTest(
         }
     }
 
+    @Test fun `compilation with unknown pokoPluginArg yields warning`() {
+        testCompilation(
+            pokoPluginArgs = "poko.nothing=value",
+        ) { result ->
+            val warning = "w: Ignoring unknown Poko plugin arg: poko.nothing"
+            assertThat(result.messages).contains(warning)
+        }
+    }
+
+    @Test fun `compilation with invalid pokoPluginArg fails`() {
+        testCompilation(
+            pokoPluginArgs = "poko.nothing",
+            expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
+        ) { result ->
+            val error = "Invalid syntax for <poko.nothing>: must be in `key=value` property format"
+            assertThat(result.messages).contains(error)
+        }
+    }
+
     private inline fun testCompilation(
         vararg sourceFileNames: String,
         pokoAnnotationName: String = "dev/drewhamilton/poko/Poko",
+        pokoPluginArgs: String? = null,
         expectedExitCode: KotlinCompilation.ExitCode = KotlinCompilation.ExitCode.OK,
         additionalTesting: (JvmCompilationResult) -> Unit = {}
     ) = testCompilation(
         *sourceFileNames.map { SourceFile.fromPath("src/test/resources/$it.kt") }.toTypedArray(),
         pokoAnnotationName = pokoAnnotationName,
+        pokoPluginArgs = pokoPluginArgs,
         expectedExitCode = expectedExitCode,
         additionalTesting = additionalTesting
     )
@@ -192,11 +213,15 @@ class PokoCompilerPluginTest(
     private inline fun testCompilation(
         vararg sourceFiles: SourceFile,
         pokoAnnotationName: String,
+        pokoPluginArgs: String? = null,
         expectedExitCode: KotlinCompilation.ExitCode = KotlinCompilation.ExitCode.OK,
         additionalTesting: (JvmCompilationResult) -> Unit = {}
     ) {
-        val result =
-            prepareCompilation(*sourceFiles, pokoAnnotationName = pokoAnnotationName).compile()
+        val result = prepareCompilation(
+            *sourceFiles,
+            pokoAnnotationName = pokoAnnotationName,
+            pokoPluginArgs = pokoPluginArgs,
+        ).compile()
         if (
             expectedExitCode == KotlinCompilation.ExitCode.OK &&
             result.exitCode != KotlinCompilation.ExitCode.OK
@@ -224,6 +249,7 @@ class PokoCompilerPluginTest(
     private fun prepareCompilation(
         vararg sourceFiles: SourceFile,
         pokoAnnotationName: String,
+        pokoPluginArgs: String?,
     ) = KotlinCompilation().apply {
         workingDir = temporaryFolder.root
         compilerPluginRegistrars = listOf(PokoCompilerPluginRegistrar())
@@ -240,13 +266,24 @@ class PokoCompilerPluginTest(
 
         val commandLineProcessor = PokoCommandLineProcessor()
         commandLineProcessors = listOf(commandLineProcessor)
-        pluginOptions = listOf(
+        val standardPluginOptions = listOf(
             commandLineProcessor.option(CompilerOptions.ENABLED, true),
             commandLineProcessor.option(CompilerOptions.POKO_ANNOTATION, pokoAnnotationName)
         )
+        pluginOptions = if (pokoPluginArgs == null) {
+            standardPluginOptions
+        } else {
+            standardPluginOptions + commandLineProcessor.option(
+                key = CompilerOptions.POKO_PLUGIN_ARGS,
+                value = pokoPluginArgs
+            )
+        }
     }
 
-    private fun CommandLineProcessor.option(key: CompilerConfigurationKey<*>, value: Any?) = PluginOption(
+    private fun CommandLineProcessor.option(
+        key: CompilerConfigurationKey<*>,
+        value: Any?,
+    ) = PluginOption(
         pluginId,
         key.toString(),
         value.toString()

--- a/poko-gradle-plugin/src/main/kotlin/dev/drewhamilton/poko/gradle/PokoGradlePlugin.kt
+++ b/poko-gradle-plugin/src/main/kotlin/dev/drewhamilton/poko/gradle/PokoGradlePlugin.kt
@@ -56,10 +56,21 @@ public class PokoGradlePlugin : KotlinCompilerPluginSupportPlugin {
         val extension = project.extensions.getByType(PokoPluginExtension::class.java)
 
         return project.provider {
-            listOf(
+            val standardOptions = listOf(
                 SubpluginOption(key = "enabled", value = extension.enabled.get().toString()),
                 SubpluginOption(key = "pokoAnnotation", value = extension.pokoAnnotation.get()),
             )
+            val pokoPluginArgs = project.properties
+                .filter { it.key.startsWith("poko.", ignoreCase = true) }
+                .map { (key, value) -> "$key=$value" }
+            return@provider if (pokoPluginArgs.isNotEmpty()) {
+                standardOptions + SubpluginOption(
+                    key = "pokoPluginArgs",
+                    value = pokoPluginArgs.joinToString(","),
+                )
+            } else {
+                standardOptions
+            }
         }
     }
 

--- a/poko-gradle-plugin/src/main/kotlin/dev/drewhamilton/poko/gradle/PokoGradlePlugin.kt
+++ b/poko-gradle-plugin/src/main/kotlin/dev/drewhamilton/poko/gradle/PokoGradlePlugin.kt
@@ -57,16 +57,24 @@ public class PokoGradlePlugin : KotlinCompilerPluginSupportPlugin {
 
         return project.provider {
             val standardOptions = listOf(
-                SubpluginOption(key = "enabled", value = extension.enabled.get().toString()),
-                SubpluginOption(key = "pokoAnnotation", value = extension.pokoAnnotation.get()),
+                SubpluginOption(
+                    key = BuildConfig.POKO_ENABLED_OPTION_NAME,
+                    value = extension.enabled.get().toString(),
+                ),
+                SubpluginOption(
+                    key = BuildConfig.POKO_ANNOTATION_OPTION_NAME,
+                    value = extension.pokoAnnotation.get(),
+                ),
             )
             val pokoPluginArgs = project.properties
                 .filter { it.key.startsWith("poko.", ignoreCase = true) }
-                .map { (key, value) -> "$key=$value" }
+                .map { (key, value) -> "$key${BuildConfig.POKO_PLUGIN_ARGS_ITEM_DELIMITER}$value" }
             return@provider if (pokoPluginArgs.isNotEmpty()) {
                 standardOptions + SubpluginOption(
                     key = "pokoPluginArgs",
-                    value = pokoPluginArgs.joinToString(","),
+                    value = pokoPluginArgs.joinToString(
+                        separator = BuildConfig.POKO_PLUGIN_ARGS_LIST_DELIMITER.toString(),
+                    ),
                 )
             } else {
                 standardOptions


### PR DESCRIPTION
Passes a list of Gradle properties starting with "poko." to the Poko compiler plugin as additional arguments. The main goal of this is to allow adding temporary feature flags that don't have to remain permanently in the Gradle plugin's API. For example, #465 can temporarily go behind a `poko.experimental.enableFirGeneration` flag so it can be smoke tested in a few different contexts without affecting regular consumers.

Unknown flags trigger a warning and are then ignored.