### PR TITLE
Separate build and test steps in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,16 +21,22 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build
-        run: ./gradlew build publishToMavenLocal --stacktrace
+        # Automatically causes :poko-annotations and :poko-compiler-plugin to build too:
+        run: ./gradlew :poko-gradle-plugin:build publishToMavenLocal --stacktrace
         env:
           ORG_GRADLE_PROJECT_personalGpgKey: ${{ secrets.ORG_GRADLE_PROJECT_personalGpgKey }}
           ORG_GRADLE_PROJECT_personalGpgPassword: ${{ secrets.ORG_GRADLE_PROJECT_personalGpgPassword }}
+
       - name: Upload MavenLocal directory
         uses: actions/upload-artifact@v4
         with:
           name: MavenLocal
           path: ~/.m2/repository/dev/drewhamilton/poko/
           if-no-files-found: error
+
+      - name: Test
+        # Builds and run tests for any not-yet-built modules, i.e. the :poko-tests modules
+        run: ./gradlew build --stacktrace
 
   test-with-jdk:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build
-        # Automatically causes :poko-annotations and :poko-compiler-plugin to build too:
-        run: ./gradlew :poko-gradle-plugin:build publishToMavenLocal --stacktrace
+        run: ./gradlew :poko-annotations:build :poko-compiler-plugin:build :poko-gradle-plugin:build publishToMavenLocal --stacktrace
         env:
           ORG_GRADLE_PROJECT_personalGpgKey: ${{ secrets.ORG_GRADLE_PROJECT_personalGpgKey }}
           ORG_GRADLE_PROJECT_personalGpgPassword: ${{ secrets.ORG_GRADLE_PROJECT_personalGpgPassword }}


### PR DESCRIPTION
I'm curious about how much time each takes separately.

I'd also ideally like to trigger the sample build(s) after the "Upload MavenLocal directory" step completes, but that's not currently possible in GitHub Actions.