### PR TITLE
Respect final Poko functions in superclass

### DIFF
--- a/poko-tests/src/commonMain/kotlin/poko/SuperclassWithFinalOverrides.kt
+++ b/poko-tests/src/commonMain/kotlin/poko/SuperclassWithFinalOverrides.kt
@@ -1,0 +1,22 @@
+package poko
+
+import dev.drewhamilton.poko.Poko
+
+open class SuperclassWithFinalOverrides(
+    private val id: String,
+) {
+    final override fun equals(other: Any?): Boolean = when {
+        this === other -> true
+        other !is SuperclassWithFinalOverrides -> false
+        else -> this.id == other.id
+    }
+
+    final override fun hashCode(): Int = 31 + id.hashCode()
+
+    final override fun toString(): String = id
+
+    @Poko class Subclass(
+        val name: String,
+    ) : SuperclassWithFinalOverrides(id = "Subclass")
+}
+

--- a/poko-tests/src/commonTest/kotlin/SuperclassWithFinalOverridesTest.kt
+++ b/poko-tests/src/commonTest/kotlin/SuperclassWithFinalOverridesTest.kt
@@ -1,25 +1,12 @@
 import assertk.all
-import assertk.assertFailure
 import assertk.assertThat
-import assertk.assertions.contains
 import assertk.assertions.hashCodeFun
 import assertk.assertions.isEqualTo
-import assertk.assertions.isNotNull
-import assertk.assertions.message
 import assertk.assertions.toStringFun
 import kotlin.test.Test
 import poko.SuperclassWithFinalOverrides
 
 class SuperclassWithFinalOverridesTest {
-
-    @Test fun failed_instantiation_with_final_function_overrides_in_superclass() {
-        val failureAssertion = assertFailure {
-            SuperclassWithFinalOverrides.Subclass(name = "unacceptable")
-        }
-        failureAssertion.message()
-            .isNotNull()
-            .contains("overrides final method")
-    }
 
     @Test fun successful_instantiation_with_final_function_overrides_in_superclass() {
         val instance = SuperclassWithFinalOverrides.Subclass(name = "this-is-fine")

--- a/poko-tests/src/commonTest/kotlin/SuperclassWithFinalOverridesTest.kt
+++ b/poko-tests/src/commonTest/kotlin/SuperclassWithFinalOverridesTest.kt
@@ -1,0 +1,32 @@
+import assertk.all
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.hashCodeFun
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.message
+import assertk.assertions.toStringFun
+import kotlin.test.Test
+import poko.SuperclassWithFinalOverrides
+
+class SuperclassWithFinalOverridesTest {
+
+    @Test fun failed_instantiation_with_final_function_overrides_in_superclass() {
+        val failureAssertion = assertFailure {
+            SuperclassWithFinalOverrides.Subclass(name = "unacceptable")
+        }
+        failureAssertion.message()
+            .isNotNull()
+            .contains("overrides final method")
+    }
+
+    @Test fun successful_instantiation_with_final_function_overrides_in_superclass() {
+        val instance = SuperclassWithFinalOverrides.Subclass(name = "this-is-fine")
+        assertThat(instance).all {
+            toStringFun().isEqualTo("Subclass")
+            hashCodeFun().isEqualTo(31 + "Subclass".hashCode())
+            isEqualTo(SuperclassWithFinalOverrides.Subclass(name = "different-name"))
+        }
+    }
+}


### PR DESCRIPTION
Fixes #471. Now, if a Poko class's superclass has a `final` override of any of the Poko functions, Poko does not generate an override of that function. Implemented for both the standard IR generation and the in-progress FIR generation.