### PR TITLE
Test compilation when superinterface declares abstract `equals` and `hashCode` functions

### DIFF
--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
@@ -35,6 +35,12 @@ class PokoCompilerPluginTest(
         testCompilation("api/Primitives")
     }
 
+    // TODO: Add similar test to :poko-tests after FIR is the only compilation mode
+    @Test fun `compilation with value interface succeeds`() {
+        assumeTrue(compilationMode == CompilationMode.K2WithFirGeneration)
+        testCompilation("api/DataInterface")
+    }
+
     @Test fun `compilation of interface fails`() {
         testCompilation(
             "illegal/Interface",

--- a/poko-compiler-plugin/src/test/resources/api/DataInterface.kt
+++ b/poko-compiler-plugin/src/test/resources/api/DataInterface.kt
@@ -1,0 +1,14 @@
+package api
+
+import dev.drewhamilton.poko.Poko
+
+interface DataInterface {
+    val id: String
+
+    override fun equals(other: Any?): Boolean
+    override fun hashCode(): Int
+}
+
+@Poko class MyData(
+    override val id: String,
+) : DataInterface


### PR DESCRIPTION
Tests the case raised in #492. Only works with FIR compilation. Does not appear to be easily fixable in non-FIR compilation, so I think I'll just enable FIR compilation by default soon.