### PR TITLE
Enable FIR compilation by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           -Dorg.gradle.project.pokoTests.jvmToolchainVersion=${{ matrix.poko_tests_jvm_toolchain_version }}
           -Dorg.gradle.project.pokoTests.compileMode=WITHOUT_K2
 
-  test-fir-generation:
+  test-non-fir-generation:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
@@ -97,7 +97,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Test
-        run: ./gradlew :poko-tests:build --stacktrace -Dorg.gradle.project.pokoTests.compileMode=FIR_GENERATION_ENABLED
+        run: ./gradlew :poko-tests:build --stacktrace -Dorg.gradle.project.pokoTests.compileMode=FIR_GENERATION_DISABLED
 
   build-sample:
     runs-on: ubuntu-latest

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCompilerPluginRegistrar.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCompilerPluginRegistrar.kt
@@ -51,13 +51,13 @@ public class PokoCompilerPluginRegistrar : CompilerPluginRegistrar() {
 
         val firDeclarationGenerationPluginValue = pokoPluginArgs[firDeclarationGenerationPluginArg]
         val firDeclarationGenerationEnabled =
-            firDeclarationGenerationPluginValue?.toBoolean()?.also {
+            firDeclarationGenerationPluginValue?.equals("false", ignoreCase = true)?.not()?.also {
                 messageCollector.report(
                     severity = CompilerMessageSeverity.WARNING,
                     message = "<$firDeclarationGenerationPluginArg> resolved to $it. " +
                         "This experimental flag may disappear at any time.",
                 )
-            } ?: false
+            } ?: true
 
         IrGenerationExtension.registerExtension(
             PokoIrGenerationExtension(

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoIrGenerationExtension.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoIrGenerationExtension.kt
@@ -22,13 +22,7 @@ internal class PokoIrGenerationExtension(
             return
         }
 
-        if (firDeclarationGeneration) {
-            if (!pluginContext.afterK2) {
-                messageCollector.report(
-                    severity = CompilerMessageSeverity.ERROR,
-                    message = "Cannot use experimental Poko FIR generation with K2 disabled"
-                )
-            }
+        if (firDeclarationGeneration && pluginContext.afterK2) {
             val bodyFiller = PokoFunctionBodyFiller(
                 pokoAnnotation = pokoAnnotationName,
                 context = pluginContext,

--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
@@ -204,22 +204,11 @@ class PokoCompilerPluginTest(
     }
 
     @Test fun `compilation with firGenerationDeclaration arg yields warning`() {
-        assumeTrue(compilationMode == CompilationMode.K2WithFirGeneration)
+        assumeTrue(compilationMode == CompilationMode.K2WithoutFirGeneration)
         testCompilation { result ->
             val warning = "w: <poko.experimental.enableFirDeclarationGeneration> resolved to " +
-                "true. This experimental flag may disappear at any time."
+                "false. This experimental flag may disappear at any time."
             assertThat(result.messages).contains(warning)
-        }
-    }
-
-    @Test fun `non-k2 compilation with firGenerationDeclaration enabled arg fails`() {
-        assumeTrue(compilationMode == CompilationMode.NotK2)
-        testCompilation(
-            pokoPluginArgs = FIR_GENERATION_ENABLED_ARG,
-            expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
-        ) { result ->
-            val error = "Cannot use experimental Poko FIR generation with K2 disabled"
-            assertThat(result.messages).contains(error)
         }
     }
 
@@ -295,8 +284,8 @@ class PokoCompilerPluginTest(
         commandLineProcessors = listOf(commandLineProcessor)
 
         @Suppress("NAME_SHADOWING") // Intentional
-        val pokoPluginArgs = if (compilationMode == CompilationMode.K2WithFirGeneration) {
-            listOfNotNull(pokoPluginArgs, FIR_GENERATION_ENABLED_ARG)
+        val pokoPluginArgs = if (compilationMode == CompilationMode.K2WithoutFirGeneration) {
+            listOfNotNull(pokoPluginArgs, FIR_GENERATION_DISABLED_ARG)
                 .joinToString(BuildConfig.POKO_PLUGIN_ARGS_LIST_DELIMITER.toString())
         } else {
             pokoPluginArgs
@@ -332,9 +321,9 @@ class PokoCompilerPluginTest(
     }
 
     private companion object {
-        private const val FIR_GENERATION_ENABLED_ARG =
+        private const val FIR_GENERATION_DISABLED_ARG =
             "poko.experimental.enableFirDeclarationGeneration" +
                 BuildConfig.POKO_PLUGIN_ARGS_ITEM_DELIMITER +
-                "true"
+                "false"
     }
 }

--- a/poko-tests/build.gradle.kts
+++ b/poko-tests/build.gradle.kts
@@ -22,14 +22,14 @@ when (compileMode) {
     }
   }
 
-  "FIR_GENERATION_ENABLED" -> {
-    logger.lifecycle("Building :poko-tests with FIR declaration generation enabled")
+  "FIR_GENERATION_DISABLED" -> {
+    logger.lifecycle("Building :poko-tests with FIR declaration generation disabled")
     tasks.withType<KotlinCompile>().configureEach {
       compilerOptions {
         freeCompilerArgs.addAll(
           listOf(
             "-P",
-            "plugin:poko-compiler-plugin:pokoPluginArgs=poko.experimental.enableFirDeclarationGeneration=true",
+            "plugin:poko-compiler-plugin:pokoPluginArgs=poko.experimental.enableFirDeclarationGeneration=false",
           ),
         )
       }


### PR DESCRIPTION
This has been tested for a few versions and appears to work fine. Fixes #492. Planning to merge after Kotlin 2.1.20 lands and cut a new release.