### PR TITLE
Revert to maven-publish-plugin 0.30.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,7 @@ asm-util = "org.ow2.asm:asm-util:9.7.1"
 testParameterInjector = "com.google.testparameterinjector:test-parameter-injector:1.18"
 
 plugin-buildconfig = "com.github.gmazzo.buildconfig:plugin:5.6.0"
-plugin-mavenPublish = "com.vanniktech:gradle-maven-publish-plugin:0.31.0"
+plugin-mavenPublish = "com.vanniktech:gradle-maven-publish-plugin:0.30.0"
 plugin-dokka = "org.jetbrains.dokka:dokka-gradle-plugin:2.0.0"
 
 [plugins]


### PR DESCRIPTION
I'm getting [weird errors](https://github.com/drewhamilton/Poko/actions/runs/14063119493/job/39446916085) publishing the latest release, and want to see whether it's the publish plugin causing them.