### PR TITLE
Add `operator` keyword to generated `equals` FIR declaration

### DIFF
--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/PokoFirDeclarationGenerationExtension.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/PokoFirDeclarationGenerationExtension.kt
@@ -151,6 +151,9 @@ internal class PokoFirDeclarationGenerationExtension(
         returnType = session.builtinTypes.booleanType.coneType,
     ) {
         modality = Modality.OPEN
+        status {
+            isOperator = true
+        }
         valueParameter(
             name = Name.identifier("other"),
             type = session.builtinTypes.nullableAnyType.coneType,

--- a/poko-tests/build.gradle.kts
+++ b/poko-tests/build.gradle.kts
@@ -42,6 +42,10 @@ when (compileMode) {
 val jvmToolchainVersion = (findProperty("pokoTests.jvmToolchainVersion") as? String)?.toInt()
 
 kotlin {
+  compilerOptions {
+    freeCompilerArgs.add("-Xexpect-actual-classes")
+  }
+
   jvmToolchainVersion?.let { jvmToolchain(it) }
 
   jvm()

--- a/poko-tests/src/commonMain/kotlin/poko/Expected.kt
+++ b/poko-tests/src/commonMain/kotlin/poko/Expected.kt
@@ -1,0 +1,7 @@
+package poko
+
+expect class Expected(
+    value: Int
+) {
+    val value: Int
+}

--- a/poko-tests/src/commonTest/kotlin/ExpectedTest.kt
+++ b/poko-tests/src/commonTest/kotlin/ExpectedTest.kt
@@ -1,0 +1,29 @@
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEqualTo
+import kotlin.test.Test
+import poko.Expected
+
+class ExpectedTest {
+    @Test fun two_equivalent_compiled_Expected_instances_are_equals() {
+        val a = Expected(1)
+        val b = Expected(1)
+        assertThat(a).isEqualTo(b)
+        assertThat(b).isEqualTo(a)
+        assertThat(a.hashCode()).isEqualTo(b.hashCode())
+    }
+
+    @Test fun two_inequivalent_compiled_Expected_instances_are_not_equals() {
+        val a = Expected(2)
+        val b = Expected(3)
+        assertThat(a).isNotEqualTo(b)
+        assertThat(b).isNotEqualTo(a)
+        assertThat(a.hashCode()).isNotEqualTo(b.hashCode())
+    }
+
+    @Test fun compiled_Expected_class_instance_has_expected_toString() {
+        val actual = Expected(4)
+        assertThat(actual.toString()).isEqualTo("Expected(value=4)")
+    }
+}

--- a/poko-tests/src/jsMain/kotlin/poko/Expected.js.kt
+++ b/poko-tests/src/jsMain/kotlin/poko/Expected.js.kt
@@ -1,0 +1,8 @@
+package poko
+
+import dev.drewhamilton.poko.Poko
+
+@Poko
+actual class Expected actual constructor(
+    actual val value: Int,
+)

--- a/poko-tests/src/jvmMain/kotlin/poko/Expected.jvm.kt
+++ b/poko-tests/src/jvmMain/kotlin/poko/Expected.jvm.kt
@@ -1,0 +1,8 @@
+package poko
+
+import dev.drewhamilton.poko.Poko
+
+@Poko
+actual class Expected actual constructor(
+    actual val value: Int,
+)

--- a/poko-tests/src/nativeMain/kotlin/poko/Expected.native.kt
+++ b/poko-tests/src/nativeMain/kotlin/poko/Expected.native.kt
@@ -1,0 +1,8 @@
+package poko
+
+import dev.drewhamilton.poko.Poko
+
+@Poko
+actual class Expected actual constructor(
+    actual val value: Int,
+)

--- a/poko-tests/src/wasmJsMain/kotlin/poko/Expected.wasmJs.kt
+++ b/poko-tests/src/wasmJsMain/kotlin/poko/Expected.wasmJs.kt
@@ -1,0 +1,8 @@
+package poko
+
+import dev.drewhamilton.poko.Poko
+
+@Poko
+actual class Expected actual constructor(
+    actual val value: Int,
+)

--- a/poko-tests/src/wasmWasiMain/kotlin/poko/Expected.wasmWasi.kt
+++ b/poko-tests/src/wasmWasiMain/kotlin/poko/Expected.wasmWasi.kt
@@ -1,0 +1,8 @@
+package poko
+
+import dev.drewhamilton.poko.Poko
+
+@Poko
+actual class Expected actual constructor(
+    actual val value: Int,
+)


### PR DESCRIPTION
The `equals` function is implicitly an `operator fun` even though it is never explicitly written as such in source code. Omitting this keyword was causing compilation for `@Poko actual` classes to fail. Fixes #503.