### PR TITLE
Filter on `ClassKind.CLASS` when resolving superclass under non-FIR compilation

### DIFF
--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
@@ -4,6 +4,7 @@ import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.impl.LazyClassReceiverParameterDescriptor
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
@@ -143,6 +144,7 @@ internal class PokoMembersTransformer(
     ): IrFunction? {
         val superclass = superTypes
             .mapNotNull { it.getClass() }
+            .filter { it.kind == ClassKind.CLASS }
             .apply { check(size < 2) { "Found multiple superclasses" } }
             .singleOrNull()
             ?: return null

--- a/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
+++ b/poko-compiler-plugin/src/test/kotlin/dev/drewhamilton/poko/PokoCompilerPluginTest.kt
@@ -41,6 +41,10 @@ class PokoCompilerPluginTest(
         testCompilation("api/DataInterface")
     }
 
+    @Test fun `compilation with multiple interfaces succeeds`() {
+        testCompilation("api/MultipleInterface")
+    }
+
     @Test fun `compilation of interface fails`() {
         testCompilation(
             "illegal/Interface",

--- a/poko-compiler-plugin/src/test/resources/api/MultipleInterface.kt
+++ b/poko-compiler-plugin/src/test/resources/api/MultipleInterface.kt
@@ -1,0 +1,18 @@
+package api
+
+import dev.drewhamilton.poko.Poko
+
+@Poko
+class MultipleInterface(
+    val int: Int,
+    val requiredString: String,
+    val optionalString: String?,
+): FunctionalInterface, MarkerInterface {
+    override fun getAnInt(): Int = int
+}
+
+interface FunctionalInterface {
+    fun getAnInt(): Int
+}
+
+interface MarkerInterface


### PR DESCRIPTION
Looks like a `filter` was missing between the logic in `PokoMembersTransform` and `PokoFirDeclarationGenerationExtension.kt`. Added a test which fails when compiling with the non-FIR mode, that then passes with 0129e131c42a8ad06641c563ba4fd1c058f673bd!

Closes #507 