### PR TITLE
Test sample builds with Kotlin language version 1.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,10 @@ jobs:
       fail-fast: false
       matrix:
         poko_sample_kotlin_version: [ 2.1.0, 2.1.10, ~, 2.2.0-Beta1 ]
+        poko_sample_kotlin_language_version: [ 1.9, ~ ]
     env:
       poko_sample_kotlin_version: ${{ matrix.poko_sample_kotlin_version }}
+      ORG_GRADLE_PROJECT_pokoSample_kotlinLanguageVersion: ${{ matrix.poko_sample_kotlin_language_version }}
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -2,6 +2,7 @@ import dev.drewhamilton.poko.sample.build.jvmToolchainLanguageVersion
 import dev.drewhamilton.poko.sample.build.kotlinJvmTarget
 import dev.drewhamilton.poko.sample.build.resolvedJavaVersion
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -18,6 +19,12 @@ apply(from = "properties.gradle")
 
 logger.lifecycle("Compiling sample app with Kotlin ${libs.versions.kotlin.get()}")
 logger.lifecycle("Targeting Java version $resolvedJavaVersion")
+
+val specifiedKotlinLanguageVersion = findProperty("pokoSample_kotlinLanguageVersion")
+    ?.toString()
+    ?.let { it.ifBlank { null } }
+    ?.let { KotlinVersion.fromVersion(it) }
+    ?.also { logger.lifecycle("Compiling sample project with language version $it") }
 
 allprojects {
     repositories {
@@ -52,10 +59,11 @@ allprojects {
         }
     }
 
-    tasks.withType<KotlinCompile> {
+    tasks.withType<KotlinCompile>().configureEach {
         compilerOptions {
-            jvmTarget.set(kotlinJvmTarget)
-            freeCompilerArgs.add("-progressive")
+            jvmTarget = kotlinJvmTarget
+            languageVersion = specifiedKotlinLanguageVersion
+            progressiveMode = (specifiedKotlinLanguageVersion == null)
         }
     }
 }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -46,15 +46,20 @@ allprojects {
         }
     }
 
-    plugins.withId("org.jetbrains.kotlin.jvm") {
-        if (jvmToolchainLanguageVersion == null) {
-            with(extensions.getByType<JavaPluginExtension>()) {
-                sourceCompatibility = resolvedJavaVersion
-                targetCompatibility = resolvedJavaVersion
-            }
-        } else {
-            extensions.getByType<KotlinJvmProjectExtension>().jvmToolchain {
-                languageVersion.set(jvmToolchainLanguageVersion)
+    listOf(
+        "org.jetbrains.kotlin.jvm",
+        "org.jetbrains.kotlin.multiplatform",
+    ).forEach { id ->
+        plugins.withId(id) {
+            if (jvmToolchainLanguageVersion == null) {
+                with(extensions.getByType<JavaPluginExtension>()) {
+                    sourceCompatibility = resolvedJavaVersion
+                    targetCompatibility = resolvedJavaVersion
+                }
+            } else {
+                extensions.getByType<KotlinJvmProjectExtension>().jvmToolchain {
+                    languageVersion.set(jvmToolchainLanguageVersion)
+                }
             }
         }
     }


### PR DESCRIPTION
Since this language version now uses a different code path (non-FIR) than newer language versions, we must test both code paths against all supported Kotlin compilers.