### PR TITLE
Test Kotlin 2.1.21-RC2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        poko_sample_kotlin_version: [ 2.1.0, 2.1.10, ~, 2.1.21-RC, 2.2.0-Beta2 ]
+        poko_sample_kotlin_version: [ 2.1.0, 2.1.10, ~, 2.1.21-RC2, 2.2.0-Beta1 ]
         poko_sample_kotlin_language_version: [ 1.9, ~ ]
     env:
       poko_sample_kotlin_version: ${{ matrix.poko_sample_kotlin_version }}


### PR DESCRIPTION
Also roll back test of Kotlin 2.2.0-Beta2, which is failing, to 2.2.0-Beta1.