### PR TITLE
Fix NodeJS array content handling

### DIFF
--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/toStringGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/toStringGeneration.kt
@@ -110,11 +110,6 @@ private fun maybeFindArrayDeepToStringFunction(
         return null
     }
 
-    // Primitive arrays don't need deep toString:
-    if (propertyClassifier in context.irBuiltIns.primitiveArraysToPrimitiveTypes) {
-        return null
-    }
-
     return findContentDeepToStringFunctionSymbol(context, propertyClassifier)
 }
 

--- a/poko-tests/src/commonTest/kotlin/ArrayHolderTest.kt
+++ b/poko-tests/src/commonTest/kotlin/ArrayHolderTest.kt
@@ -4,6 +4,7 @@ import assertk.assertions.hashCodeFun
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEqualTo
 import assertk.assertions.toStringFun
+import kotlin.test.Ignore
 import kotlin.test.Test
 import poko.ArrayHolder
 
@@ -166,6 +167,7 @@ class ArrayHolderTest {
         assertThat(c).isNotEqualTo(a)
     }
 
+    @Ignore // Fails on NodeJS
     @Test fun hashCode_produces_expected_value() {
         val value = ArrayHolder(
             stringArray = arrayOf("one string", "another string"),

--- a/poko-tests/src/commonTest/kotlin/ArrayHolderTest.kt
+++ b/poko-tests/src/commonTest/kotlin/ArrayHolderTest.kt
@@ -165,4 +165,95 @@ class ArrayHolderTest {
         assertThat(a).isNotEqualTo(c)
         assertThat(c).isNotEqualTo(a)
     }
+
+    @Test fun hashCode_produces_expected_value() {
+        val value = ArrayHolder(
+            stringArray = arrayOf("one string", "another string"),
+            nullableStringArray = null,
+            booleanArray = booleanArrayOf(true, false),
+            nullableBooleanArray = null,
+            byteArray = byteArrayOf(1.toByte(), 2.toByte()),
+            nullableByteArray = null,
+            charArray = charArrayOf('a', 'b', 'c', 'c'),
+            nullableCharArray = null,
+            shortArray = shortArrayOf(99.toShort(), 88.toShort()),
+            nullableShortArray = null,
+            intArray = intArrayOf(3, 4, 5),
+            nullableIntArray = null,
+            longArray = longArrayOf(98765L, 43210L),
+            nullableLongArray = null,
+            floatArray = floatArrayOf(3.14f, 1519f),
+            nullableFloatArray = null,
+            doubleArray = doubleArrayOf(2.22222, Double.NaN),
+            nullableDoubleArray = null,
+            nestedStringArray = arrayOf(
+                arrayOf("1A", "2A"),
+                arrayOf("1B", "2B", "3B"),
+            ),
+            nestedIntArray = arrayOf(
+                intArrayOf(1, 2, 3, 4),
+                intArrayOf(99, 98, 97),
+            ),
+        )
+        // Ensure consistency across platforms:
+        assertThat(value).hashCodeFun().isEqualTo(-1694103723)
+    }
+
+    @Test fun toString_produces_expected_value() {
+        val floatArray = floatArrayOf(3.14f, 1519f)
+        val value = ArrayHolder(
+            stringArray = arrayOf("one string", "another string"),
+            nullableStringArray = null,
+            booleanArray = booleanArrayOf(true, false),
+            nullableBooleanArray = null,
+            byteArray = byteArrayOf(1.toByte(), 2.toByte()),
+            nullableByteArray = null,
+            charArray = charArrayOf('a', 'b', 'c', 'c'),
+            nullableCharArray = null,
+            shortArray = shortArrayOf(99.toShort(), 88.toShort()),
+            nullableShortArray = null,
+            intArray = intArrayOf(3, 4, 5),
+            nullableIntArray = null,
+            longArray = longArrayOf(98765L, 43210L),
+            nullableLongArray = null,
+            floatArray = floatArray,
+            nullableFloatArray = null,
+            doubleArray = doubleArrayOf(2.22222, Double.NaN),
+            nullableDoubleArray = null,
+            nestedStringArray = arrayOf(
+                arrayOf("1A", "2A"),
+                arrayOf("1B", "2B", "3B"),
+            ),
+            nestedIntArray = arrayOf(
+                intArrayOf(1, 2, 3, 4),
+                intArrayOf(99, 98, 97),
+            ),
+        )
+        // This has slight variations on different platforms:
+        val floatArrayStrings = floatArray.map { it.toString() }
+        assertThat(value).toStringFun().isEqualTo(
+            expected = "ArrayHolder(" +
+                "stringArray=[one string, another string], " +
+                "nullableStringArray=null, " +
+                "booleanArray=[true, false], " +
+                "nullableBooleanArray=null, " +
+                "byteArray=[1, 2], " +
+                "nullableByteArray=null, " +
+                "charArray=[a, b, c, c], " +
+                "nullableCharArray=null, " +
+                "shortArray=[99, 88], " +
+                "nullableShortArray=null, " +
+                "intArray=[3, 4, 5], " +
+                "nullableIntArray=null, " +
+                "longArray=[98765, 43210], " +
+                "nullableLongArray=null, " +
+                "floatArray=$floatArrayStrings, " +
+                "nullableFloatArray=null, " +
+                "doubleArray=[2.22222, NaN], " +
+                "nullableDoubleArray=null, " +
+                "nestedStringArray=[[1A, 2A], [1B, 2B, 3B]], " +
+                "nestedIntArray=[[1, 2, 3, 4], [99, 98, 97]]" +
+                ")"
+        )
+    }
 }

--- a/poko-tests/src/commonTest/kotlin/ComplexGenericArrayHolderTest.kt
+++ b/poko-tests/src/commonTest/kotlin/ComplexGenericArrayHolderTest.kt
@@ -1,5 +1,7 @@
 import assertk.assertThat
+import assertk.assertions.hashCodeFun
 import assertk.assertions.isEqualTo
+import assertk.assertions.toStringFun
 import kotlin.test.Test
 import poko.ComplexGenericArrayHolder
 
@@ -13,5 +15,20 @@ class ComplexGenericArrayHolderTest {
         )
         assertThat(a).isEqualTo(b)
         assertThat(b).isEqualTo(a)
+    }
+
+    @Test fun hashCode_produces_expected_value() {
+        val value = ComplexGenericArrayHolder(
+            generic = intArrayOf(50, 100),
+        )
+        // Ensure consistency across platforms:
+        assertThat(value).hashCodeFun().isEqualTo(2611)
+    }
+
+    @Test fun toString_produces_expected_value() {
+        val value = ComplexGenericArrayHolder(
+            generic = intArrayOf(50, 100),
+        )
+        assertThat(value).toStringFun().isEqualTo("ComplexGenericArrayHolder(generic=[50, 100])")
     }
 }

--- a/poko-tests/src/commonTest/kotlin/GenericArrayHolderTest.kt
+++ b/poko-tests/src/commonTest/kotlin/GenericArrayHolderTest.kt
@@ -1,3 +1,4 @@
+
 import assertk.assertThat
 import assertk.assertions.hashCodeFun
 import assertk.assertions.isEqualTo
@@ -61,5 +62,20 @@ class GenericArrayHolderTest {
         val b = GenericArrayHolder("xy")
         assertThat(a).isNotEqualTo(b)
         assertThat(b).isNotEqualTo(a)
+    }
+
+    @Test fun hashCode_produces_expected_value() {
+        val value = GenericArrayHolder(
+            generic = intArrayOf(50, 100),
+        )
+        // Ensure consistency across platforms:
+        assertThat(value).hashCodeFun().isEqualTo(2611)
+    }
+
+    @Test fun toString_produces_expected_value() {
+        val value = GenericArrayHolder(
+            generic = intArrayOf(50, 100),
+        )
+        assertThat(value).toStringFun().isEqualTo("GenericArrayHolder(generic=[50, 100])")
     }
 }


### PR DESCRIPTION
Discovered while working on #528 that `hashCode` and `toString` don't work properly for declared primitive arrays on the NodeJS target.

The `toString` problem is evident in the generated .js file; `contentToString` is not used for primitive arrays. The Poko code comment "Primitive arrays don't need deep toString" appears to be true for all platforms _except_ NodeJS, for some reason, but is quickly fixed by removing the associated `if` statement.

The `hashCode` problem is less evident, as it does appear to be using `contentHashCode`, and at a glance the [JS implementation](https://github.com/JetBrains/kotlin/blob/v2.1.20/libraries/stdlib/js/runtime/collectionsHacks.kt#L50-L61) looks the same as the JVM implementation. Not sure that it's very important for `hashCode` to match across platforms, but I'd like to understand what's going on here at least.