### PR TITLE
Use new `IrFunction.parameters` property

### DIFF
--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/PokoMembersTransformer.kt
@@ -125,8 +125,7 @@ internal class PokoMembersTransformer(
     private fun canOverride(function: IrFunction): Boolean {
         val superclassSameFunction = function.parentAsClass.findNearestSuperclassFunction(
             name = function.name,
-            valueParameters = function.valueParameters,
-            extensionReceiverParameter = function.extensionReceiverParameter,
+            parameters = function.parametersCompat
         )
 
         return superclassSameFunction?.isOverridable ?: true
@@ -139,8 +138,7 @@ internal class PokoMembersTransformer(
     @OptIn(UnsafeDuringIrConstructionAPI::class)
     private fun IrClass.findNearestSuperclassFunction(
         name: Name,
-        valueParameters: List<IrValueParameter>,
-        extensionReceiverParameter: IrValueParameter?,
+        parameters: List<IrValueParameter>,
     ): IrFunction? {
         val superclass = superTypes
             .mapNotNull { it.getClass() }
@@ -153,16 +151,14 @@ internal class PokoMembersTransformer(
             .filterIsInstance<IrFunction>()
             .filter { function ->
                 function.name == name &&
-                    function.valueParameters.map { it.type } == valueParameters.map { it.type } &&
-                    function.extensionReceiverParameter == extensionReceiverParameter
+                    function.parametersCompat.map { it.type } == parameters.map { it.type }
             }
             .apply { check(size < 2) { "Found multiple identical superclass functions" } }
             .singleOrNull()
 
         return superclassFunction ?: superclass.findNearestSuperclassFunction(
             name = name,
-            valueParameters = valueParameters,
-            extensionReceiverParameter = extensionReceiverParameter,
+            parameters = parameters,
         )
     }
 

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/compat.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/compat.kt
@@ -27,6 +27,7 @@ import org.jetbrains.kotlin.ir.builders.irString
 import org.jetbrains.kotlin.ir.builders.irWhen
 import org.jetbrains.kotlin.ir.declarations.IrField
 import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.declarations.IrValueDeclaration
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.expressions.IrBranch
@@ -539,4 +540,20 @@ internal val IrFunction.parametersCompat: List<IrValueParameter>
                 add(it)
             }
         }
+    }
+
+/**
+ * Alias for filtering [IrFunction.parameters] to only regular parameters for compatibility with
+ * 2.1.0 – 2.1.1x. Throws if the function has context parameters on 2.1.1x or lower.
+ *
+ * Remove when support for 2.1.1x is dropped.
+ */
+internal val IrFunction.regularParametersCompat: List<IrValueParameter>
+    get() = try {
+        parameters.filter { it.kind == IrParameterKind.Regular }
+    } catch (noSuchMethodError: NoSuchMethodError) {
+        require(contextReceiverParametersCount == 0) {
+            "regularParametersCompat is not supported on functions with context parameters"
+        }
+        valueParameters
     }

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/compat.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/compat.kt
@@ -413,7 +413,6 @@ private fun Array<Method>.findIrBuilderExtension(
 internal fun IrBuilderWithScope.irCallCompat(
     callee: IrSimpleFunctionSymbol,
     type: IrType,
-    valueArgumentsCount: Int = callee.owner.valueParameters.size,
     typeArgumentsCount: Int = callee.owner.typeParameters.size,
     origin: IrStatementOrigin? = null,
 ): IrCall {
@@ -460,7 +459,7 @@ internal fun IrBuilderWithScope.irCallCompat(
                     this, // extension receiver
                     callee, // param: callee
                     type, // param: type
-                    valueArgumentsCount, // param: valueArgumentsCount
+                    -1, // param: valueArgumentsCount (unused)
                     typeArgumentsCount, // param: typeArgumentsCount
                     origin, // param: origin
                 )

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/compat.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/compat.kt
@@ -557,3 +557,19 @@ internal val IrFunction.regularParametersCompat: List<IrValueParameter>
         }
         valueParameters
     }
+
+/**
+ * Convenience for determining whether a function is the canonical `hashCode` function, for
+ * compatibility with 2.1.0 – 2.1.1x.
+ *
+ * Remove when support for 2.1.1x is dropped.
+ */
+internal fun IrFunction.isHashCodeFunctionCompat(): Boolean {
+    if (name.asString() != "hashCode") return false
+
+    return try {
+        parameters == parameters.filter { it.kind == IrParameterKind.DispatchReceiver }
+    } catch (noSuchMethodError: NoSuchMethodError) {
+        valueParameters.isEmpty() && extensionReceiverParameter == null
+    }
+}

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/compat.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/compat.kt
@@ -26,7 +26,9 @@ import org.jetbrains.kotlin.ir.builders.irSet
 import org.jetbrains.kotlin.ir.builders.irString
 import org.jetbrains.kotlin.ir.builders.irWhen
 import org.jetbrains.kotlin.ir.declarations.IrField
+import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrValueDeclaration
+import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.expressions.IrBranch
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
@@ -517,3 +519,25 @@ internal fun IrElement.acceptChildrenVoidCompat(visitor: IrVisitorVoid) {
         acceptChildren(visitor, null)
     }
 }
+
+/**
+ * Alias for [IrFunction.parameters] for compatibility with 2.1.0 – 2.1.1x. Throws if the function
+ * has context parameters on 2.1.1x or lower.
+ *
+ * Remove when support for 2.1.1x is dropped.
+ */
+internal val IrFunction.parametersCompat: List<IrValueParameter>
+    get() = try {
+        parameters
+    } catch (noSuchMethodError: NoSuchMethodError) {
+        require(contextReceiverParametersCount == 0) {
+            "parametersCompat is not supported on functions with context parameters"
+        }
+        buildList {
+            dispatchReceiverParameter?.let { add(it) }
+            extensionReceiverParameter?.let { add(it) }
+            valueParameters.forEach {
+                add(it)
+            }
+        }
+    }

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/equalsGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/equalsGeneration.kt
@@ -184,7 +184,6 @@ private fun IrBuilderWithScope.irCallContentDeepEquals(
     return irCallCompat(
         callee = findContentDeepEqualsFunctionSymbol(context, classifier),
         type = context.irBuiltIns.booleanType,
-        valueArgumentsCount = 1,
         typeArgumentsCount = 1,
     ).apply {
         extensionReceiver = receiver

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/equalsGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/equalsGeneration.kt
@@ -43,7 +43,9 @@ internal fun IrBlockBodyBuilder.generateEqualsMethodBody(
     messageCollector: MessageCollector,
 ) {
     val irType = irClass.defaultType
-    fun irOther(): IrExpression = IrGetValueImpl(functionDeclaration.valueParameters.single())
+    fun irOther(): IrExpression = IrGetValueImpl(
+        parameter = functionDeclaration.regularParametersCompat.single(),
+    )
 
     +irIfThenReturnTrue(irEqeqeqCompat(receiver(functionDeclaration), irOther()))
     +irIfThenReturnFalse(irNotIsCompat(irOther(), irType))

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
@@ -328,7 +328,6 @@ private fun IrBlockBodyBuilder.irCallHashCodeFunction(
     return irCallCompat(
         callee = hashCodeFunctionSymbol,
         type = context.irBuiltIns.intType,
-        valueArgumentsCount = if (hasDispatchReceiver || hasExtensionReceiver) 0 else 1,
         typeArgumentsCount = 0,
     ).apply {
         when {

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/ir/hashCodeGeneration.kt
@@ -306,9 +306,7 @@ private fun IrBlockBodyBuilder.getHashCodeFunctionForClass(
     irClass: IrClass
 ): IrSimpleFunctionSymbol {
     val explicitHashCodeDeclaration = irClass.functions.singleOrNull {
-        it.name.asString() == "hashCode" &&
-            it.valueParameters.isEmpty() &&
-            it.extensionReceiverParameter == null
+        it.isHashCodeFunctionCompat()
     }
     return explicitHashCodeDeclaration?.symbol
         ?: context.irBuiltIns.anyClass.functions.single { it.owner.name.asString() == "hashCode" }


### PR DESCRIPTION
This API is introduced in 2.1.20 and required in 2.2.x. See https://github.com/JetBrains/kotlin/blob/master/docs/backend/IR_parameter_api_migration.md.