### PR TITLE
Update publishing to Sonatype Central Portal

### DIFF
--- a/build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildPlugin.kt
+++ b/build-support/src/main/java/dev/drewhamilton/poko/build/PokoBuildPlugin.kt
@@ -78,7 +78,7 @@ class PokoBuildPlugin : Plugin<Project> {
 
                 signAllPublications()
                 publishToMavenCentral(
-                    host = SonatypeHost.DEFAULT,
+                    host = SonatypeHost.CENTRAL_PORTAL,
                     automaticRelease = true,
                 )
             }


### PR DESCRIPTION
The old portal is being [shut down](https://central.sonatype.org/news/20250326_ossrh_sunset/).