### PR TITLE
Test Kotlin 2.20.0-Beta1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        poko_sample_kotlin_version: [ ~ ]
+        poko_sample_kotlin_version: [ ~, 2.2.20-Beta1 ]
         poko_sample_kotlin_language_version: [ 1.9, ~ ]
     env:
       poko_sample_kotlin_version: ${{ matrix.poko_sample_kotlin_version }}

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/PokoFirDeclarationGenerationExtension.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/PokoFirDeclarationGenerationExtension.kt
@@ -158,7 +158,7 @@ internal class PokoFirDeclarationGenerationExtension(
         processAllDeclaredCallables(session) { callableSymbol ->
             if (
                 callableSymbol is FirNamedFunctionSymbol &&
-                !callableSymbol.isExtension &&
+                !callableSymbol.isExtensionCompat() &&
                 callableSymbol.name == function.functionName &&
                 callableSymbol.valueParameterSymbols
                     .map { it.resolvedReturnType } == function.valueParameterTypes()

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/compat.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/compat.kt
@@ -1,0 +1,24 @@
+package dev.drewhamilton.poko.fir
+
+import org.jetbrains.kotlin.fir.symbols.impl.FirCallableSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.isExtension
+
+internal fun FirCallableSymbol<*>.isExtensionCompat(): Boolean {
+    return try {
+        isExtension
+    } catch (noSuchMethodError: NoSuchMethodError) {
+        // 2.2.20:
+        javaClass.classLoader
+            .loadClass("org.jetbrains.kotlin.fir.declarations.utils.FirDeclarationUtilKt")
+            .methods
+            .single {
+                it.name == "isExtension" &&
+                    it.parameters.size == 1 &&
+                    it.parameters.single().type == FirCallableSymbol::class.java
+            }
+            .invoke(
+                null, // Static invocation
+                this, // Extension receiver
+            ) as Boolean
+    }
+}


### PR DESCRIPTION
Adds forward compatibility with the changed signature for the FIR `isExtension` extension. Addresses the initial problem mentioned in #561.