### PR TITLE
Build Gradle plugin with compatibility with Kotlin 2.1

### DIFF
--- a/poko-gradle-plugin/build.gradle.kts
+++ b/poko-gradle-plugin/build.gradle.kts
@@ -1,6 +1,25 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     `java-gradle-plugin`
     id("org.jetbrains.kotlin.jvm")
+}
+
+kotlin {
+    compilerOptions {
+        /* Versions used here should be no more than one Kotlin release ahead of the Kotlin version embedded with the
+        oldest supported Gradle version. Gradle 8.11 embeds Kotlin 2.0 so this plugin will be compatible if using Kotlin
+        2.1 or older: https://docs.gradle.org/current/userguide/compatibility.html */
+        apiVersion = KotlinVersion.KOTLIN_2_1
+        languageVersion = KotlinVersion.KOTLIN_2_1
+    }
+}
+
+tasks.withType(KotlinCompile::class).configureEach {
+    compilerOptions {
+        progressiveMode = false
+    }
 }
 
 pokoBuild {


### PR DESCRIPTION
This will ensure compatibility with Gradle 8.11 which embeds Kotlin 2.0.x, which is forward compatible with Kotlin 2.1.

It will also be compatible with all newer Gradle versions that embed Kotlin versions that are backwards-compatible with Kotlin 2.1.

Fixes #557