### PR TITLE
Enable Kotlin metadata version check in sample project

### DIFF
--- a/sample/gradle.properties
+++ b/sample/gradle.properties
@@ -1,1 +1,4 @@
 android.useAndroidX=true
+
+// https://docs.gradle.org/8.5/release-notes.html#kotlin-dsl-improvements
+org.gradle.kotlin.dsl.skipMetadataVersionCheck=false


### PR DESCRIPTION
Enabling the metadata version check will stop allowing loading of classes with bad metadata versions or pre-release classes.

This should stop #557 recurring. Test by bumping this to 2.2 or 2.3 then building the sample project - it should now fail:

https://github.com/drewhamilton/Poko/blob/1231efdf533a25a0b5383bbeaef91453d167eaa0/poko-gradle-plugin/build.gradle.kts#L14-L15