### PR TITLE
Update sample project Gradle scripts

### DIFF
--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -1,15 +1,11 @@
-import dev.drewhamilton.poko.sample.build.jvmToolchainLanguageVersion
+
 import dev.drewhamilton.poko.sample.build.kotlinJvmTarget
 import dev.drewhamilton.poko.sample.build.resolvedJavaVersion
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    val ciJavaVersion = dev.drewhamilton.poko.sample.build.ciJavaVersion
-    if (ciJavaVersion == null || ciJavaVersion >= 17) {
-        alias(libs.plugins.android.library) apply false
-    }
+    alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.multiplatform) apply false
@@ -51,15 +47,9 @@ allprojects {
         "org.jetbrains.kotlin.multiplatform",
     ).forEach { id ->
         plugins.withId(id) {
-            if (jvmToolchainLanguageVersion == null) {
-                with(extensions.getByType<JavaPluginExtension>()) {
-                    sourceCompatibility = resolvedJavaVersion
-                    targetCompatibility = resolvedJavaVersion
-                }
-            } else {
-                extensions.getByType<KotlinJvmProjectExtension>().jvmToolchain {
-                    languageVersion.set(jvmToolchainLanguageVersion)
-                }
+            with(extensions.getByType<JavaPluginExtension>()) {
+                sourceCompatibility = resolvedJavaVersion
+                targetCompatibility = resolvedJavaVersion
             }
         }
     }

--- a/sample/buildSrc/src/main/kotlin/dev/drewhamilton/poko/sample/build/java.kt
+++ b/sample/buildSrc/src/main/kotlin/dev/drewhamilton/poko/sample/build/java.kt
@@ -4,17 +4,7 @@ import org.gradle.api.JavaVersion
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
-val ciJavaVersion: Int? = System.getenv()["ci_java_version"]?.toInt()
-
-val jvmToolchainLanguageVersion: JavaLanguageVersion? = ciJavaVersion?.let {
-    JavaLanguageVersion.of(ciJavaVersion.toInt())
-}
-
-val resolvedJavaVersion: JavaVersion = when (ciJavaVersion) {
-    null -> JavaVersion.VERSION_11
-    8, 9, 10 -> JavaVersion.valueOf("VERSION_1_$ciJavaVersion")
-    else -> JavaVersion.valueOf("VERSION_$ciJavaVersion")
-}
+val resolvedJavaVersion: JavaVersion = JavaVersion.VERSION_11
 
 val kotlinJvmTarget: JvmTarget = when (resolvedJavaVersion) {
     JavaVersion.VERSION_1_8 -> JvmTarget.JVM_1_8

--- a/sample/compose/build.gradle.kts
+++ b/sample/compose/build.gradle.kts
@@ -22,7 +22,7 @@ if (jvmToolchainLanguageVersion != null) {
 
 android {
     namespace = "dev.drewhamilton.poko.sample.compose"
-    compileSdk = 34
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 21
@@ -33,8 +33,10 @@ android {
         targetCompatibility(resolvedJavaVersion)
     }
 
-    kotlinOptions {
-        freeCompilerArgs = listOf("-progressive")
+    kotlin {
+        compilerOptions {
+            progressiveMode.set(true)
+        }
     }
 
     buildFeatures {
@@ -43,8 +45,9 @@ android {
         // Disable unused AGP features
         resValues = false
         shaders = false
-        androidResources = false
     }
+
+    androidResources.enable = false
 }
 
 dependencies {

--- a/sample/compose/build.gradle.kts
+++ b/sample/compose/build.gradle.kts
@@ -1,4 +1,3 @@
-import dev.drewhamilton.poko.sample.build.jvmToolchainLanguageVersion
 import dev.drewhamilton.poko.sample.build.resolvedJavaVersion
 
 plugins {
@@ -10,14 +9,6 @@ plugins {
 
 poko {
     pokoAnnotation.set("dev/drewhamilton/poko/sample/compose/Poko")
-}
-
-if (jvmToolchainLanguageVersion != null) {
-    kotlin {
-        jvmToolchain {
-            languageVersion.set(jvmToolchainLanguageVersion)
-        }
-    }
 }
 
 android {

--- a/sample/settings.gradle.kts
+++ b/sample/settings.gradle.kts
@@ -42,14 +42,7 @@ rootProject.name = "PokoSample"
 
 include(":jvm")
 include(":mpp")
-
-// Android requires JDK 17; skip it on CI tests for lower JDKs
-private val ciJavaVersion = System.getenv()["ci_java_version"]?.toInt()
-if (ciJavaVersion == null || ciJavaVersion >= 17) {
-    include(":compose")
-} else {
-    logger.lifecycle("Testing on JDK $ciJavaVersion; skipping :compose module")
-}
+include(":compose")
 
 private val isCi = System.getenv()["CI"] == "true"
 if (!isCi) {


### PR DESCRIPTION
Replace deprecated APIs with non-deprecated ones. Drop logic around varying Java versions for testing, which we don't use anymore in the sample project. Bump Android sample to compile with Android SDK 36.