### PR TITLE
Revert `pluginId` to internal

### DIFF
--- a/poko-compiler-plugin/api/poko-compiler-plugin.api
+++ b/poko-compiler-plugin/api/poko-compiler-plugin.api
@@ -11,7 +11,6 @@ public final class dev/drewhamilton/poko/PokoCommandLineProcessor : org/jetbrain
 
 public final class dev/drewhamilton/poko/PokoCompilerPluginRegistrar : org/jetbrains/kotlin/compiler/plugin/CompilerPluginRegistrar {
 	public fun <init> ()V
-	public final fun getPluginId ()Ljava/lang/String;
 	public fun getSupportsK2 ()Z
 	public fun registerExtensions (Lorg/jetbrains/kotlin/compiler/plugin/CompilerPluginRegistrar$ExtensionStorage;Lorg/jetbrains/kotlin/config/CompilerConfiguration;)V
 }

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCompilerPluginRegistrar.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/PokoCompilerPluginRegistrar.kt
@@ -20,7 +20,9 @@ import org.jetbrains.kotlin.name.ClassId
 public class PokoCompilerPluginRegistrar : CompilerPluginRegistrar() {
 
     // TODO: Update for 2.3.0
-    public val pluginId: String get() = BuildConfig.COMPILER_PLUGIN_ARTIFACT
+    @Suppress("unused") // Added for forward compatibility
+    @get:JvmName("getPluginId")
+    internal val pluginId: String get() = BuildConfig.COMPILER_PLUGIN_ARTIFACT
 
     override val supportsK2: Boolean get() = true
 


### PR DESCRIPTION
Use `@JvmName` to ensure it's available to the 2.3.0-RC compiler.