### PR TITLE
Add disambiguation attribute to `:poko-gradle-plugin` configurations

### DIFF
--- a/poko-gradle-plugin/build.gradle.kts
+++ b/poko-gradle-plugin/build.gradle.kts
@@ -33,6 +33,10 @@ kotlin {
     jvmToolchain(minimumGradleJavaVersion)
 }
 
+private val disambiguationAttribute = Attribute.of(
+    "dev.drewhamilton.poko.gradle.disambiguation-attribute",
+    String::class.java,
+)
 configurations.configureEach {
     if (isCanBeConsumed) {
         attributes {
@@ -40,6 +44,10 @@ configurations.configureEach {
                 GradlePluginApiVersion.GRADLE_PLUGIN_API_VERSION_ATTRIBUTE,
                 objects.named(minimumGradleVersion),
             )
+
+            // Configurations are not allowed to have an identical attribute set, so add a unique
+            // attribute to disambiguate:
+            attribute(disambiguationAttribute, this@configureEach.name)
         }
     }
 }

--- a/sample/gradle.properties
+++ b/sample/gradle.properties
@@ -1,4 +1,4 @@
 android.useAndroidX=true
 
-// https://docs.gradle.org/8.5/release-notes.html#kotlin-dsl-improvements
+# https://docs.gradle.org/8.5/release-notes.html#kotlin-dsl-improvements
 org.gradle.kotlin.dsl.skipMetadataVersionCheck=false


### PR DESCRIPTION
After #655, the IDE was locally failing to sync the sample project, because outputs from `:poko-gradle-plugin` had identical attributes. The error message suggested adding a disambiguation attribute, so I added the configuration name as a separate attribute to guarantee it will be unique across configurations.

Also fixed a mis-formatted comment in sample/gradle.properties.