### PR TITLE
Gradle Plugin: Remove remaining get() calls to preserver Provider dep…

### DIFF
--- a/poko-gradle-plugin/src/main/kotlin/dev/drewhamilton/poko/gradle/PokoGradlePlugin.kt
+++ b/poko-gradle-plugin/src/main/kotlin/dev/drewhamilton/poko/gradle/PokoGradlePlugin.kt
@@ -55,18 +55,25 @@ public class PokoGradlePlugin : KotlinCompilerPluginSupportPlugin {
         val project = kotlinCompilation.target.project
         val extension = project.extensions.getByType(PokoPluginExtension::class.java)
 
-        return project.provider {
-            listOfNotNull(
+        val optionsProvider = project.objects.listProperty(SubpluginOption::class.java)
+        optionsProvider.add(
+            extension.enabled.map {
                 SubpluginOption(
                     key = BuildConfig.POKO_ENABLED_OPTION_NAME,
-                    value = extension.enabled.get().toString(),
-                ),
+                    value = it.toString(),
+                )
+            }
+        )
+        optionsProvider.add(
+            extension.pokoAnnotation.map {
                 SubpluginOption(
                     key = BuildConfig.POKO_ANNOTATION_OPTION_NAME,
-                    value = extension.pokoAnnotation.get(),
-                ),
-            )
-        }
+                    value = it,
+                )
+            }
+        )
+
+        return optionsProvider
     }
 
     private val BuildConfig.annotationsDependency: String


### PR DESCRIPTION
…endencies

You should never call `get()` outside a task action.
Ideally, Gradle would never implement a `Provider.get` member...