### PR TITLE
Remove unnecessary disambiguation attributes from Gradle plugin

### DIFF
--- a/poko-gradle-plugin/build.gradle.kts
+++ b/poko-gradle-plugin/build.gradle.kts
@@ -33,10 +33,6 @@ kotlin {
     jvmToolchain(minimumGradleJavaVersion)
 }
 
-private val disambiguationAttribute = Attribute.of(
-    "dev.drewhamilton.poko.gradle.disambiguation-attribute",
-    String::class.java,
-)
 configurations.configureEach {
     if (isCanBeConsumed) {
         attributes {
@@ -44,11 +40,14 @@ configurations.configureEach {
                 GradlePluginApiVersion.GRADLE_PLUGIN_API_VERSION_ATTRIBUTE,
                 objects.named(minimumGradleVersion),
             )
-
-            // Configurations are not allowed to have an identical attribute set, so add a unique
-            // attribute to disambiguate:
-            attribute(disambiguationAttribute, this@configureEach.name)
         }
+    }
+}
+
+// Workaround for clash between `signature` and `archives`; remove when bumping to Gradle 10:
+configurations.archives {
+    attributes {
+        attribute(Attribute.of("deprecated", String::class.java), "true")
     }
 }
 


### PR DESCRIPTION
The only necessary one is for `archives`, which is deprecated and clashes with `signature`.

This is a followup to #659, with the implementation [suggested there by](https://github.com/drewhamilton/Poko/pull/659#issuecomment-3772039699) @hfhbd.