### PR TITLE
Build the sample projects on CI with Java 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,8 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: zulu
-          java-version: 25
+          # Minimum supported Java version for Gradle:
+          java-version: 17
       - name: Download MavenLocal
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
This is the lowest Java version supported by Gradle.