### PR TITLE
Add Gradle test fixture for AGP 8

### DIFF
--- a/poko-gradle-plugin/src/test/fixtures/simple-android-agp8/build.gradle.kts
+++ b/poko-gradle-plugin/src/test/fixtures/simple-android-agp8/build.gradle.kts
@@ -1,0 +1,31 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    id("com.android.library") version "8.8.2"
+    id("org.jetbrains.kotlin.android") version libs.versions.kotlin.get()
+    alias(libs.plugins.poko)
+}
+
+android {
+    namespace = "dev.drewhamilton.poko.gradle.test.android.agp8"
+    compileSdk = 36
+
+    defaultConfig {
+        minSdk = 21
+    }
+
+    compileOptions {
+        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlin {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
+    }
+}
+
+dependencies {
+    testImplementation(libs.junit)
+}

--- a/poko-gradle-plugin/src/test/fixtures/simple-android-agp8/settings.gradle.kts
+++ b/poko-gradle-plugin/src/test/fixtures/simple-android-agp8/settings.gradle.kts
@@ -1,0 +1,24 @@
+pluginManagement {
+    repositories {
+        maven {
+            setUrl(rootDir.resolve("../../../../../build/localMaven"))
+        }
+        mavenCentral()
+        google()
+    }
+}
+
+dependencyResolutionManagement {
+    versionCatalogs.register("libs") {
+        from(files("../../../../../gradle/libs.versions.toml"))
+        plugin("poko", "dev.drewhamilton.poko").version(providers.gradleProperty("pokoVersion").get())
+    }
+
+    repositories {
+        maven {
+            setUrl(rootDir.resolve("../../../../../build/localMaven"))
+        }
+        mavenCentral()
+        google()
+    }
+}

--- a/poko-gradle-plugin/src/test/fixtures/simple-android-agp8/src/main/kotlin/com/example/User.kt
+++ b/poko-gradle-plugin/src/test/fixtures/simple-android-agp8/src/main/kotlin/com/example/User.kt
@@ -1,0 +1,9 @@
+package com.example
+
+import dev.drewhamilton.poko.Poko
+
+@Poko
+class User(
+    val name: String,
+    val age: Int,
+)

--- a/poko-gradle-plugin/src/test/fixtures/simple-android-agp8/src/test/kotlin/com/example/UserTest.kt
+++ b/poko-gradle-plugin/src/test/fixtures/simple-android-agp8/src/test/kotlin/com/example/UserTest.kt
@@ -1,0 +1,13 @@
+package com.example
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UserTest {
+    @Test
+    fun valuey() {
+        val alice1 = User("alice", 25)
+        val alice2 = User("alice", 25)
+        assertEquals(alice1, alice2)
+    }
+}

--- a/poko-gradle-plugin/src/test/fixtures/simple-android/build.gradle.kts
+++ b/poko-gradle-plugin/src/test/fixtures/simple-android/build.gradle.kts
@@ -11,7 +11,7 @@ buildscript {
 }
 
 android {
-    namespace = "dev.drewhamilton.poko.test"
+    namespace = "dev.drewhamilton.poko.gradle.test.android"
     compileSdk = 36
 
     defaultConfig {

--- a/poko-gradle-plugin/src/test/kotlin/dev/drewhamilton/poko/gradle/PokoGradlePluginFixtureTest.kt
+++ b/poko-gradle-plugin/src/test/kotlin/dev/drewhamilton/poko/gradle/PokoGradlePluginFixtureTest.kt
@@ -1,8 +1,8 @@
 package dev.drewhamilton.poko.gradle
 
 import assertk.assertThat
-import assertk.assertions.doesNotContain
 import assertk.assertions.contains
+import assertk.assertions.doesNotContain
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import dev.drewhamilton.poko.gradle.TestBuildConfig.MINIMUM_GRADLE_VERSION
@@ -35,6 +35,11 @@ class PokoGradlePluginFixtureTest(
         }
 
         val result = createRunner(File("src/test/fixtures/simple-android")).build()
+        assertThat(result.output).contains(BuildConfig.annotationsDependency)
+    }
+
+    @Test fun simpleAndroidAgp8() {
+        val result = createRunner(File("src/test/fixtures/simple-android-agp8")).build()
         assertThat(result.output).contains(BuildConfig.annotationsDependency)
     }
 


### PR DESCRIPTION
AGP 8 works significantly differently than AGP 9, so it's worth testing separately.