### PR TITLE
Restore compatibility with 2.4.0-dev for IntelliJ

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,9 +72,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Note: periodically update dev version with latest from
-        # https://packages.jetbrains.team/maven/p/kt/bootstrap/org/jetbrains/kotlin/kotlin-gradle-plugin/
-        poko_sample_kotlin_version: [ ~ ]
+        # Note: periodically update dev versions with latest from
+        # https://packages.jetbrains.team/maven/p/kt/bootstrap/org/jetbrains/kotlin/kotlin-gradle-plugin/.
+        # Keep past dev versions too; try to target active versions of IntelliJ based on tags in
+        # https://github.com/JetBrains/kotlin. Can also use
+        # https://github.com/ZacSweers/metro/blob/main/docs/compatibility.md as a reference.
+        poko_sample_kotlin_version: [ 2.4.0-dev-2124, ~, 2.4.20-dev-4664 ]
     env:
       poko_sample_kotlin_version: ${{ matrix.poko_sample_kotlin_version }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
           cache-provider: basic
 
       - name: Upgrade yarn lock
-        if: ${{ matrix.poko_sample_kotlin_version != null }}
+        if: ${{ matrix.poko_sample_kotlin_version != null && !startsWith(matrix.poko_sample_kotlin_version, '2.4.0-dev') }}
         run: cd sample && ./gradlew kotlinUpgradeYarnLock
 
       - name: Build sample

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/PokoFirDeclarationGenerationExtension.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/PokoFirDeclarationGenerationExtension.kt
@@ -10,7 +10,6 @@ import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
 import org.jetbrains.kotlin.fir.declarations.processAllDeclaredCallables
-import org.jetbrains.kotlin.fir.declarations.utils.isExtension
 import org.jetbrains.kotlin.fir.declarations.utils.isFinal
 import org.jetbrains.kotlin.fir.declarations.utils.visibility
 import org.jetbrains.kotlin.fir.extensions.FirDeclarationGenerationExtension
@@ -162,7 +161,7 @@ internal class PokoFirDeclarationGenerationExtension(
         val matchingFunctions = mutableListOf<FirNamedFunctionSymbol>()
         scope.processFunctionsByName(function.functionName) { functionSymbol ->
             if (
-                !functionSymbol.isExtension &&
+                !functionSymbol.isExtensionCompat() &&
                 functionSymbol.valueParameterSymbols
                     .map { it.resolvedReturnType } == function.valueParameterTypes()
             ) {
@@ -204,7 +203,7 @@ internal class PokoFirDeclarationGenerationExtension(
         processAllDeclaredCallables(session) { callableSymbol ->
             if (
                 callableSymbol is FirNamedFunctionSymbol &&
-                !callableSymbol.isExtension &&
+                !callableSymbol.isExtensionCompat() &&
                 callableSymbol.name == function.functionName &&
                 callableSymbol.valueParameterSymbols
                     .map { it.resolvedReturnType } == function.valueParameterTypes()

--- a/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/compat.kt
+++ b/poko-compiler-plugin/src/main/kotlin/dev/drewhamilton/poko/fir/compat.kt
@@ -1,0 +1,23 @@
+package dev.drewhamilton.poko.fir
+
+import org.jetbrains.kotlin.fir.declarations.utils.isExtension
+import org.jetbrains.kotlin.fir.symbols.impl.FirCallableSymbol
+
+internal fun FirCallableSymbol<*>.isExtensionCompat(): Boolean {
+    return try {
+        isExtension
+    } catch (_: NoSuchMethodError) {
+        // 2.4.0-dev (IJ 2026.1):
+        javaClass.classLoader
+            .loadClass("org.jetbrains.kotlin.fir.declarations.utils.FirDeclarationUtilKt")
+            .methods
+            .single { it.name == "isExtension" &&
+                it.parameters.size == 1 &&
+                it.parameters[0].type == FirCallableSymbol::class.java
+            }
+            .invoke(
+                null, // Static invocation
+                this, // Extension receiver
+            ) as Boolean
+    }
+}

--- a/sample/settings.gradle.kts
+++ b/sample/settings.gradle.kts
@@ -50,9 +50,16 @@ plugins {
 
 rootProject.name = "PokoSample"
 
+// Compile sample project with different Kotlin version than Poko, if provided:
+private val localKotlinVersionOverride: String? = null
+private val kotlinVersionOverride = localKotlinVersionOverride
+    ?: System.getenv()["poko_sample_kotlin_version"]?.ifBlank { null }
+
 include(":jvm")
-include(":mpp")
 include(":compose")
+if (kotlinVersionOverride?.startsWith("2.4.0-dev") != true) {
+    include(":mpp")
+}
 
 private val isCi = System.getenv()["CI"] == "true"
 if (!isCi) {
@@ -79,12 +86,6 @@ dependencyResolutionManagement {
         create("libs") {
             from(files("../gradle/libs.versions.toml"))
 
-            fun String.nullIfBlank(): String? = if (isNullOrBlank()) null else this
-
-            // Compile sample project with different Kotlin version than Poko, if provided:
-            val localKotlinVersionOverride: String? = null
-            val kotlinVersionOverride = localKotlinVersionOverride
-                ?: System.getenv()["poko_sample_kotlin_version"]?.nullIfBlank()
             kotlinVersionOverride?.let { kotlinVersion ->
                 version("kotlin", kotlinVersion)
             }


### PR DESCRIPTION
IJ 2026.1 is still using 2.4.0-dev that predates some 2.4.0 API changes.